### PR TITLE
Standard python logger objects do not have a notify() method.

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -174,9 +174,9 @@ def writefile(dest, content, overwrite=True):
         f.close()
         if c != content:
             if not overwrite:
-                logger.notify(' * File %s exists with different content; not overwriting', dest)
+                logger.info(' * File %s exists with different content; not overwriting', dest)
                 return
-            logger.notify(' * Overwriting %s with new content', dest)
+            logger.info(' * Overwriting %s with new content', dest)
             f = open(dest, 'wb')
             f.write(content.encode('utf-8'))
             f.close()


### PR DESCRIPTION
This patch switches from notify() to info(), which seems appropriate.

I think notify() was left over from the virtualenv script.
