### PR TITLE
fixed print_node_versions() is always missing the 8th element

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -404,11 +404,10 @@ def print_node_versions():
         if not row:
             logger.info('\t'.join(rowx))
             break
+        rowx.append(row.replace('\n', ''))
         if pos % 8 == 0:
             logger.info('\t'.join(rowx))
             rowx = []
-        else:
-            rowx.append(row.replace('\n', ''))
 
 
 def get_last_stable_node_version():


### PR DESCRIPTION
For example, missing '0.1.1', '0.1.9', '0.1.17' etc.

Original output sample:
"""
0.0.1   0.0.2   0.0.3   0.0.4   0.0.5   0.0.6   0.1.0
0.1.2   0.1.3   0.1.4   0.1.5   0.1.6   0.1.7   0.1.8
0.1.10  0.1.11  0.1.12  0.1.13  0.1.14  0.1.15  0.1.16
0.1.18  0.1.19  0.1.20  0.1.21  0.1.22  0.1.23  0.1.24
0.1.26  0.1.27  0.1.28  0.1.29  0.1.30  0.1.31  0.1.32
0.1.90  0.1.91  0.1.92  0.1.93  0.1.94  0.1.95  0.1.96
0.1.98  0.1.99  0.1.100 0.1.101 0.1.102 0.1.103 0.1.104
0.2.1   0.2.2   0.2.3   0.2.4   0.2.5   0.2.6   0.3.0
0.3.2   0.3.3   0.3.4   0.3.5   0.3.6   0.3.7   0.3.8
0.4.1   0.4.2   0.4.3   0.4.4   0.4.5   0.4.6   0.4.7
0.4.9   0.4.10  0.4.11  0.4.12  0.5.0   0.5.1   0.5.2
0.5.4   0.5.5   0.5.6   0.5.7   0.5.8   0.5.9   0.5.10
0.6.1   0.6.2   0.6.3   0.6.4   0.6.5   0.6.6   0.6.7
0.7.0
"""

Fixed output sample:
"""
0.0.1   0.0.2   0.0.3   0.0.4   0.0.5   0.0.6   0.1.0   0.1.1
0.1.2   0.1.3   0.1.4   0.1.5   0.1.6   0.1.7   0.1.8   0.1.9
0.1.10  0.1.11  0.1.12  0.1.13  0.1.14  0.1.15  0.1.16  0.1.17
0.1.18  0.1.19  0.1.20  0.1.21  0.1.22  0.1.23  0.1.24  0.1.25
0.1.26  0.1.27  0.1.28  0.1.29  0.1.30  0.1.31  0.1.32  0.1.33
0.1.90  0.1.91  0.1.92  0.1.93  0.1.94  0.1.95  0.1.96  0.1.97
0.1.98  0.1.99  0.1.100 0.1.101 0.1.102 0.1.103 0.1.104 0.2.0
0.2.1   0.2.2   0.2.3   0.2.4   0.2.5   0.2.6   0.3.0   0.3.1
0.3.2   0.3.3   0.3.4   0.3.5   0.3.6   0.3.7   0.3.8   0.4.0
0.4.1   0.4.2   0.4.3   0.4.4   0.4.5   0.4.6   0.4.7   0.4.8
0.4.9   0.4.10  0.4.11  0.4.12  0.5.0   0.5.1   0.5.2   0.5.3
0.5.4   0.5.5   0.5.6   0.5.7   0.5.8   0.5.9   0.5.10  0.6.0
0.6.1   0.6.2   0.6.3   0.6.4   0.6.5   0.6.6   0.6.7   0.6.8
0.7.0
"""
