### PR TITLE
nodeenv fixes for current node.js and npm releases.

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -433,8 +433,9 @@ def get_last_stable_node_version():
     Return last stable node.js version
     """
     p = subprocess.Popen(
-        "curl -s http://nodejs.org/dist/ | "
-        "egrep -o '[0-9]+\.[2468]+\.[0-9]+' | "
+        "curl -s http://nodejs.org/dist/latest/ | "
+        "egrep -o 'node-v[0-9]+\.[0-9]+\.[0-9]+' | "
+        "sed -e 's/node-v//' | "
         "sort -u -k 1,1n -k 2,2n -k 3,3n -t . | "
         "tail -n1",
         shell=True, stdout=subprocess.PIPE)


### PR DESCRIPTION
nodeenv is pulling node.js 0.8.5 as current but it's still RC. This update uses the /dist/latest/ directory to identify current stable.

Also, NPM now serves from HTTPS so NPM install fails with the current curl options.

thanks,
Travis
