### PR TITLE
Don't use `--insecure` to download npm

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -329,7 +329,7 @@ def install_npm(env_dir, src_dir, opt):
     """
     logger.info(' * Install npm.js (%s) ... ' % opt.npm,
                     extra=dict(continued=True))
-    cmd = ['. %s && curl --insecure --silent %s | clean=%s npm_install=%s bash && deactivate_node' % (
+    cmd = ['. %s && curl --silent %s | clean=%s npm_install=%s bash && deactivate_node' % (
             join(env_dir, 'bin', 'activate'),
             'https://npmjs.org/install.sh',
             'no' if opt.no_npm_clean else 'yes',


### PR DESCRIPTION
npmjs.org certificate is legit. We don't need to use `--insecure` flag
with curl. This fixes #18.
