### PR TITLE
Remove `src` directory after installation of node.js

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -402,6 +402,8 @@ def create_environment(env_dir, opt):
         install_npm(env_dir, src_dir, opt)
     if opt.requirements:
         install_packages(env_dir, opt)
+    # Cleanup
+    callit(['rm -rf', src_dir], opt.verbose, True, env_dir)
 
 
 def print_node_versions():


### PR DESCRIPTION
This directory takes a lot of disk space and is not useful for most
users. This fixes #19.
