### PR TITLE
Various small fixes and tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: deploy deploy-github deploy-pypi update-pypi clean test
 
 deploy-github:
-	git tag `grep "nodeenv_version =" nodeenv.py | grep -o -E '[0-9]\.[0-9]\.[0-9]{1,2}'`
+	git tag `grep "nodeenv_version =" nodeenv.py | sed 's/.*= *//;s/'\'//g`
 	git push --tags origin master
 
 deploy-pypi:

--- a/nodeenv.py
+++ b/nodeenv.py
@@ -10,7 +10,7 @@
     :license: BSD, see LICENSE for more details.
 """
 
-nodeenv_version = '0.6.1'
+nodeenv_version = '0.6.1.1'
 
 import sys
 import os


### PR DESCRIPTION
This correctly passes -j/--jobs to Make, adds --load-average as another way to control Make paralleliism, and changes the default to not installing npm (as it is not needed normally). Plus a few small tweaks to wording and such.
