### PR TITLE
Add an option to use system-wide "node"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,6 +114,10 @@ for compilation and npm.js "0.3.17"::
 
     $ nodeenv --without-ssl --node=0.4.3 --npm=0.3.17 --jobs=4 env-4.3
 
+Create a new environment with the system-wide node.js::
+
+    $ nodeenv --node=system
+
 Saving into the file versions of all installed packages::
 
     $ . env-4.3/bin/activate

--- a/nodeenv.py
+++ b/nodeenv.py
@@ -79,7 +79,8 @@ def parse_args():
         metavar='NODE_VER', default=get_last_stable_node_version(),
         help='The node.js version to use, e.g., '
         '--node=0.4.3 will use the node-v0.4.3 '
-        'to create the new environment. The default is last stable version.')
+        'to create the new environment. The default is last stable version. '
+        'Use `system` to use system-wide node.')
 
     parser.add_option('-j', '--jobs', dest='jobs', default='2',
         help='Sets number of parallel commands at node.js compilation. '
@@ -433,7 +434,12 @@ def create_environment(env_dir, opt):
     mkdir(src_dir)
     save_env_options(env_dir, opt)
 
-    install_node(env_dir, src_dir, opt)
+    if opt.node != "system":
+        install_node(env_dir, src_dir, opt)
+    else:
+        mkdir(join(env_dir, 'bin'))
+        mkdir(join(env_dir, 'lib'))
+        mkdir(join(env_dir, 'lib', 'node_modules'))
     # activate script install must be
     # before npm install, npm use activate
     # for install
@@ -549,6 +555,10 @@ deactivate_node () {
         NODE_PATH="$_OLD_NODE_PATH"
         export NODE_PATH
         unset _OLD_NODE_PATH
+
+        NPM_CONFIG_PREFIX="$_OLD_NPM_CONFIG_PREFIX"
+        export NPM_CONFIG_PREFIX
+        unset _OLD_NPM_CONFIG_PREFIX
     fi
 
     # This should detect bash and zsh, which have a hash command that must
@@ -614,6 +624,10 @@ export PATH
 _OLD_NODE_PATH="$NODE_PATH"
 NODE_PATH="$NODE_VIRTUAL_ENV/__MOD_NAME__"
 export NODE_PATH
+
+_OLD_NPM_CONFIG_PREFIX="$NPM_CONFIG_PREFIX"
+NPM_CONFIG_PREFIX="$NODE_VIRTUAL_ENV"
+export NPM_CONFIG_PREFIX
 
 if [ -z "$NODE_VIRTUAL_ENV_DISABLE_PROMPT" ] ; then
     _OLD_NODE_VIRTUAL_PS1="$PS1"


### PR DESCRIPTION
Using `-n system` flag, node.js will not be downloaded nor
compiled. The system-wide version will be used. npm needs to be
tricked a bit about using the appropriate prefix. We enforce the
prefix to be used by setting NPM_CONFIG_PREFIX variable in the
environment.

This should fix #17.
