### PR TITLE
Allow . in package name. Allow build/prerelease tags from npm

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -608,7 +608,7 @@ freeze () {
                   cut -d ' ' -f 1 | grep -v npm`
     else
         NPM_LIST=`npm ls -g | grep -E '^.{4}\w{1}' | \
-                 grep -o -E '[a-zA-Z0-9\.\-]+@[0-9]+\.[0-9]+\.[0-9]+([\+-]+[a-zA-Z0-9\.\-]+)?' | \
+                 grep -o -E '[a-zA-Z0-9\.\-]+@[0-9]+\.[0-9]+\.[0-9]+([\+\-][a-zA-Z0-9\.\-]+)*' | \
                  grep -v npm`
     fi
 


### PR DESCRIPTION
This fixes Issue #47

Based on the NPM documentation version numbers must be parsed by node-semver which is based on the [semver](http://semver.org/) syntax. This apparently includes not just a major.minor.patch, but optionally prerelease on postrelease tags in the version number. 

For example, in phantomjs, if you do "npm -g install phantomjs" the version installed is 1.9.2-6. The "-6" represents a prelease tag, and needs to be included in the output of freeze to correctly pull from npm. Otherwise attempting to install phantomjs via the requirements file will fail as there is no 1.9.2 on npm. Other examples of valid version numbers from semver.org include:

`1.0.0-alpha+001, 1.0.0+20130313144700, 1.0.0-beta+exp.sha.5114f85.`

The freeze regex was modified to include these. You can see some testing of this regex [here](http://regexpal.com/?flags=g&regex=%5Ba-zA-Z0-9%5C.%5C-%5D%2B%40%5B0-9%5D%2B%5C.%5B0-9%5D%2B%5C.%5B0-9%5D%2B%28%5B%5C%2B%5C-%5D%5Ba-zA-Z0-9%5C.%5C-%5D%2B%29*&input=%E2%94%9C%E2%94%80%E2%94%AC%20bower%401.2.8%0A%E2%94%9C%E2%94%80%E2%94%AC%20generator-angular%400.7.1%0A%E2%94%9C%E2%94%80%E2%94%AC%20generator-karma%400.6.0%0A%E2%94%9C%E2%94%80%E2%94%AC%20grunt%400.4.2%0A%E2%94%9C%E2%94%80%E2%94%AC%20grunt-cli%400.1.11%0A%E2%94%9C%E2%94%80%E2%94%AC%20grunt-karma%400.6.2%0A%E2%94%9C%E2%94%80%E2%94%AC%20karma%400.10.9%0A%E2%94%9C%E2%94%80%E2%94%80%20karma-chrome-launcher%400.1.2%0A%E2%94%9C%E2%94%80%E2%94%AC%20karma-coffee-preprocessor%400.1.2%0A%E2%94%9C%E2%94%80%E2%94%80%20karma-firefox-launcher%400.1.3%0A%E2%94%9C%E2%94%80%E2%94%80%20karma-html2js-preprocessor%400.1.0%0A%E2%94%9C%E2%94%80%E2%94%80%20karma-jasmine%400.1.5%0A%E2%94%9C%E2%94%80%E2%94%AC%20karma-phantomjs-launcher%400.1.1%0A%E2%94%9C%E2%94%80%E2%94%80%20karma-requirejs%400.2.1%0A%E2%94%9C%E2%94%80%E2%94%80%20karma-script-launcher%400.1.0%0A%E2%94%9C%E2%94%80%E2%94%AC%20npm%401.3.21%0A%E2%94%9C%E2%94%80%E2%94%AC%20phantomjs%401.9.2-6%0A%E2%94%9C%E2%94%80%E2%94%80%20requirejs%402.1.9%0A%E2%94%9C%E2%94%80%E2%94%AC%20socket.io%400.9.16%0A%E2%94%94%E2%94%80%E2%94%AC%20yo%401.1.1%0Afoo%401.0.0-beta%2Bexp.sha.5114f85%0Abar%401.0.0-0.3.7%0Afoo%401.0.0-x.7.z.92%0Af.o.o.js%401.0.0-x.7.z.92_shouldn'tmatch%0A). Testing was also perfromed locally by using this version of nodeenv in my project and refreezing and reinstalling everything from scratch.

In a related issue, some packages, notably socket.io have a period in the package name. Some packages that include ".js" also have this problem. A period is not listed an an allowable package name character in the regex. This has been added.
