### PR TITLE
npm.js redirect

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -403,7 +403,7 @@ def install_npm(env_dir, src_dir, opt):
     logger.info(' * Install npm.js (%s) ... ' % opt.npm,
                 extra=dict(continued=True))
     cmd = [
-        '. %s && curl --silent %s | '
+        '. %s && curl --location --silent %s | '
         'clean=%s npm_install=%s bash && deactivate_node' % (
             pipes.quote(join(env_dir, 'bin', 'activate')),
             'https://www.npmjs.org/install.sh',


### PR DESCRIPTION
Two small fixes: the first one to use the new location of `install.sh` and the second one to avoid the same problem in the future.
