### PR TITLE
Python 3 support

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -222,14 +222,14 @@ def writefile(dest, content, overwrite=True, append=False):
         f = open(dest, 'rb')
         c = f.read()
         f.close()
-        if c != content:
+        if c != content.encode('utf-8'):
             if not overwrite:
                 logger.info(' * File %s exists with different content; '
                             ' not overwriting', dest)
                 return
             if append:
                 logger.info(' * Appending nodeenv settings to %s', dest)
-                f = open(dest, 'a')
+                f = open(dest, 'ab')
                 f.write(DISABLE_POMPT.encode('utf-8'))
                 f.write(content.encode('utf-8'))
                 f.write(ENABLE_PROMPT.encode('utf-8'))


### PR DESCRIPTION
This pull request fixes #42 (support for python 3.*) . The solution relies on the fact that there is a python2 executable, and it can be found via the "which python2" command.
- Temporarily pointing the python executable to the python2 for ./configure, make, make install. The Node.js build scripts are currently using python 2.*. We should start to advocate for python3 support there, but this may take some time.
- Fixed some inconsistences causing the writefile() function to fail in python 3.*

This solution was tested with success on Ubuntu Linux 13.10, with python 2.7.5 and 3.3.2 preinstalled.
- on python 3 virtualenv created by pyenv-3.3 command and patched with following commands:
  
  ```
  wget https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py -O - | python
  wget https://raw.github.com/pypa/pip/master/contrib/get-pip.py -O - | python
  ```
  
  (setuptools & pip are included from the 3.4 version AFAIK)
- on python 2 virtualenv created by virtualenv command
