### PR TITLE
fix node version parsing when using --node=system

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -10,7 +10,7 @@
     :license: BSD, see LICENSE for more details.
 """
 
-nodeenv_version = '0.8.0'
+nodeenv_version = '0.8.1'
 
 import sys
 import os
@@ -34,6 +34,16 @@ abspath = os.path.abspath
 # ---------------------------------------------------------
 # Utils
 
+def node_version_from_opt(opt):
+    """
+    Parse the node version from the optparse options
+    """
+    if opt.node == 'system':
+        out, err = subprocess.Popen(
+            ["node", "--version"], stdout=subprocess.PIPE).communicate()
+        return parse_version(out.replace('\n','').replace('v', ''))
+
+    return parse_version(opt.node)
 
 def create_logger():
     """
@@ -522,7 +532,7 @@ def create_environment(env_dir, opt):
     # before npm install, npm use activate
     # for install
     install_activate(env_dir, opt)
-    if parse_version(opt.node) < parse_version("0.6.3") or opt.with_npm:
+    if node_version_from_opt(opt) < parse_version("0.6.3") or opt.with_npm:
         install_npm(env_dir, src_dir, opt)
     if opt.requirements:
         install_packages(env_dir, opt)


### PR DESCRIPTION
When opt.node is set to 'system', parse_version(opt.node) invariantly returns ('_system', '_final') which is always less than parse_version("0.6.3"). I've changed the code to check the node version on the system if the developer wants to use the system node.
