### PR TITLE
exclude top-level files in prebuilt tar

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -348,7 +348,7 @@ def download_node(node_url, src_dir, env_dir, opt):
     cmd.append(pipes.quote(src_dir))
     cmd.extend(['--exclude', 'ChangeLog'])
     cmd.extend(['--exclude', 'LICENSE'])
-    cmd.extend(['--exclude', 'README'])
+    cmd.extend(['--exclude', 'README.md'])
     try:
         callit(cmd, opt.verbose, True, env_dir)
         logger.info(') ', extra=dict(continued=True))


### PR DESCRIPTION
This fixes #63
