### PR TITLE
Properly escape (quote) passed on arguments when calling the real node executable

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -675,7 +675,7 @@ unset NODE_VIRTUAL_ENV_DISABLE_PROMPT
 SHIM = """#!/usr/bin/env bash
 export NODE_PATH=__NODE_VIRTUAL_ENV__/lib/node_modules
 export NPM_CONFIG_PREFIX=__NODE_VIRTUAL_ENV__
-exec __SHIM_NODE__ $*
+exec __SHIM_NODE__ "$@"
 """
 
 ACTIVATE_SH = """


### PR DESCRIPTION
$\* leads to problems with spaces WITHIN arguments; transparent passing on args needs "$@".
