### PR TITLE
Detect virtualenv using python instead of environment variable

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -640,11 +640,10 @@ def get_last_stable_node_version():
 
 def get_env_dir(opt, args):
     if opt.python_virtualenv:
-        try:
-            return os.environ['VIRTUAL_ENV']
-        except KeyError:
-            logger.error('No python virtualenv is available')
-            sys.exit(2)
+        if hasattr(sys, 'real_prefix'):
+            return sys.prefix
+        logger.error('No python virtualenv is available')
+        sys.exit(2)
     else:
         return args[0]
 


### PR DESCRIPTION
Currently nodeenv uses `$VIRTUAL_ENV` to determine the virtualenv path. Python scripts using the venv interpreter (including scripts in `<prefix>/bin/`) still run under the virtual environment even when `$VIRTUAL_ENV` isn't set. This fix allows the nodeenv command to be called directly without needing to first activate the virtualenv.
