### PR TITLE
append only to activate script if nodeenv code is not already present

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -338,23 +338,24 @@ def writefile(dest, content, overwrite=True, append=False):
         f = open(dest, 'rb')
         c = f.read()
         f.close()
+        content = content.encode('utf-8')
 
         if append:
-            if content.encode('utf-8') not in c:
+            if content not in c:
                 logger.info(' * Appending nodeenv settings to %s', dest)
                 f = open(dest, 'ab')
                 f.write(DISABLE_POMPT.encode('utf-8'))
-                f.write(content.encode('utf-8'))
+                f.write(content)
                 f.write(ENABLE_PROMPT.encode('utf-8'))
                 f.close()
-        elif c != content.encode('utf-8'):
+        elif c != content:
             if not overwrite:
                 logger.info(' * File %s exists with different content; '
                             ' not overwriting', dest)
                 return
             logger.info(' * Overwriting %s with new content', dest)
             f = open(dest, 'wb')
-            f.write(content.encode('utf-8'))
+            f.write(content)
             f.close()
         else:
             logger.debug(' * Content %s already in place', dest)


### PR DESCRIPTION
simple fix for #94

IMHO a better solution would be to move the code into its own file (for example activate.nodeenv) and only append a single line to the original nodeenv script.  This would keep the activate script cleaner and allow for easy updating the script.  If welcome I would implement it.
