### PR TITLE
npm: use npm_config_prefix instead of NPM_CONFIG_PREFIX

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -769,6 +769,7 @@ unset NODE_VIRTUAL_ENV_DISABLE_PROMPT
 SHIM = """#!/usr/bin/env bash
 export NODE_PATH=__NODE_VIRTUAL_ENV__/lib/node_modules
 export NPM_CONFIG_PREFIX=__NODE_VIRTUAL_ENV__
+export npm_config_prefix=__NODE_VIRTUAL_ENV__
 exec __SHIM_NODE__ "$@"
 """
 
@@ -789,8 +790,11 @@ deactivate_node () {
         unset _OLD_NODE_PATH
 
         NPM_CONFIG_PREFIX="$_OLD_NPM_CONFIG_PREFIX"
+        npm_config_prefix="$_OLD_npm_config_prefix"
         export NPM_CONFIG_PREFIX
+        export npm_config_prefix
         unset _OLD_NPM_CONFIG_PREFIX
+        unset _OLD_npm_config_prefix
     fi
 
     # This should detect bash and zsh, which have a hash command that must
@@ -865,8 +869,11 @@ NODE_PATH="$NODE_VIRTUAL_ENV/__MOD_NAME__"
 export NODE_PATH
 
 _OLD_NPM_CONFIG_PREFIX="$NPM_CONFIG_PREFIX"
+_OLD_npm_config_prefix="$npm_config_prefix"
 NPM_CONFIG_PREFIX="$NODE_VIRTUAL_ENV"
+npm_config_prefix="$NODE_VIRTUAL_ENV"
 export NPM_CONFIG_PREFIX
+export npm_config_prefix
 
 if [ -z "$NODE_VIRTUAL_ENV_DISABLE_PROMPT" ] ; then
     _OLD_NODE_VIRTUAL_PS1="$PS1"


### PR DESCRIPTION
Recent versions of npm (at least 1.4.21) don't accept
NPM_CONFIG_PREFIX being valid. They expect the lower-case version
instead. Since I don't know for sure that older versions also accept
that, I keep both of them.
