### PR TITLE
Disallow prefix overridden by .npmrc

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -782,6 +782,7 @@ unset NODE_VIRTUAL_ENV_DISABLE_PROMPT
 SHIM = """#!/usr/bin/env bash
 export NODE_PATH=__NODE_VIRTUAL_ENV__/lib/node_modules
 export NPM_CONFIG_PREFIX=__NODE_VIRTUAL_ENV__
+export npm_config_prefix=__NODE_VIRTUAL_ENV__
 exec __SHIM_NODE__ "$@"
 """
 
@@ -804,6 +805,10 @@ deactivate_node () {
         NPM_CONFIG_PREFIX="$_OLD_NPM_CONFIG_PREFIX"
         export NPM_CONFIG_PREFIX
         unset _OLD_NPM_CONFIG_PREFIX
+
+        npm_config_prefix="$_OLD_npm_config_prefix"
+        export npm_config_prefix
+        unset _OLD_npm_config_prefix
     fi
 
     # This should detect bash and zsh, which have a hash command that must
@@ -881,6 +886,10 @@ export NODE_PATH
 _OLD_NPM_CONFIG_PREFIX="$NPM_CONFIG_PREFIX"
 NPM_CONFIG_PREFIX="$NODE_VIRTUAL_ENV"
 export NPM_CONFIG_PREFIX
+
+_OLD_npm_config_prefix="$npm_config_prefix"
+npm_config_prefix="$NODE_VIRTUAL_ENV"
+export npm_config_prefix
 
 if [ -z "$NODE_VIRTUAL_ENV_DISABLE_PROMPT" ] ; then
     _OLD_NODE_VIRTUAL_PS1="$PS1"


### PR DESCRIPTION
This is causing https://github.com/pre-commit/pre-commit/issues/165

Here's a test I used to regression test this.  I noticed there aren't any checked-in tests so I'm not sure how we'll prevent this from regressing.

```
#!/usr/bin/env bash
if [ -e ~/.npmrc ]; then
    echo "NPMRC ALREADY EXISTS, THIS SCRIPT CLOBBERS IT. ABORTING"
    exit 1
fi

mkdir -p /tmp/my-node-env
echo 'prefix=/tmp/my-node-env' > ~/.npmrc

rm nenv -rf
nodeenv nenv --prebuilt
. nenv/bin/activate
npm install -g eslint
# This will fail if we did not install into our nodeenv!
which eslint
if [ $? -eq 0 ]; then
    echo 'PASSED!'
else
    echo 'FAILED :('
fi

# Cleanup
rm ~/.npmrc
rm -rf /tmp/my-node-env
```

Before:

```
$ ./test.sh 
 * Install node.js (0.10.31) ... done.
/tmp/my-node-env/bin/eslint -> /tmp/my-node-env/lib/node_modules/eslint/bin/eslint.js
eslint@0.7.4 /tmp/my-node-env/lib/node_modules/eslint
├── object-assign@0.3.1
├── strip-json-comments@0.1.3
├── debug@0.8.1
├── estraverse@1.3.2
├── escope@1.0.1
├── text-table@0.2.0
├── chalk@0.4.0 (has-color@0.1.7, ansi-styles@1.0.0, strip-ansi@0.1.1)
├── doctrine@0.5.2
├── minimatch@0.3.0 (sigmund@1.0.0, lru-cache@2.5.0)
├── mkdirp@0.5.0 (minimist@0.0.8)
├── optionator@0.4.0 (type-check@0.3.1, deep-is@0.1.3, levn@0.2.5, prelude-ls@1.1.1, wordwrap@0.0.2, fast-levenshtein@1.0.3)
├── esprima@1.2.2
└── js-yaml@3.0.2 (esprima@1.0.4, argparse@0.1.15)
FAILED :(
```

After:

```
$ ./test.sh 
 * Install node.js (0.10.31) ... done.
/home/anthony/workspace/nodeenv/nenv/bin/eslint -> /home/anthony/workspace/nodeenv/nenv/lib/node_modules/eslint/bin/eslint.js
eslint@0.7.4 /home/anthony/workspace/nodeenv/nenv/lib/node_modules/eslint
├── object-assign@0.3.1
├── strip-json-comments@0.1.3
├── debug@0.8.1
├── estraverse@1.3.2
├── escope@1.0.1
├── text-table@0.2.0
├── chalk@0.4.0 (has-color@0.1.7, ansi-styles@1.0.0, strip-ansi@0.1.1)
├── doctrine@0.5.2
├── minimatch@0.3.0 (sigmund@1.0.0, lru-cache@2.5.0)
├── mkdirp@0.5.0 (minimist@0.0.8)
├── optionator@0.4.0 (type-check@0.3.1, deep-is@0.1.3, levn@0.2.5, prelude-ls@1.1.1, wordwrap@0.0.2, fast-levenshtein@1.0.3)
├── esprima@1.2.2
└── js-yaml@3.0.2 (esprima@1.0.4, argparse@0.1.15)
/home/anthony/workspace/nodeenv/nenv/bin/eslint
PASSED!
```
