### PR TITLE
:lipstick: fix rest description

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -36,7 +36,7 @@ Version 0.9.6
 -------------
 - Removed ``os.symlink`` added in `# 76`_. See `# 84`_
 
-.._# 84: https://github.com/ekalinin/nodeenv/issues/84
+.. _# 84: https://github.com/ekalinin/nodeenv/issues/84
 
 Version 0.9.5
 -------------

--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,7 @@ or on Debian using `dpkg`_::
     $ dpkg-buildpackage -uc -us -b
     $ sudo dpkg -i $(ls -1rt ../nodeenv_*.deb | tail -n1)
 
+.. _dpkg: https://www.debian.org/doc/manuals/debian-faq/ch-pkgtools.en.html
 
 Local installation
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
```
$ virtualenv env
$ source env/bin/activate
$ pip install collective.checkdocs
$ python setup.py checkdocs
running checkdocs
<string>:39: (ERROR/3) Unknown target name: "dpkg".
<string>:300: (ERROR/3) Unknown target name: "# 84".
<string>:308: (ERROR/3) Unknown target name: "# 84".
error: long_description had reST syntax errors
```
