### PR TITLE
Remove dep for lxml in favor of stdlib HTMLParser

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,30 @@
+[run]
+branch = True
+source =
+    .
+omit =
+    .tox/*
+    /usr/*
+    */tmp*
+    setup.py
+    # Don't complain if non-runnable code isn't run
+    */__main__.py
+
+[report]
+exclude_lines =
+    # Have to re-enable the standard pragma
+    \#\s*pragma: no cover
+
+    # Don't complain if tests don't hit defensive assertion code:
+    ^\s*raise AssertionError\b
+    ^\s*raise NotImplementedError\b
+    ^\s*return NotImplemented\b
+    ^\s*raise$
+
+    # Don't complain if non-runnable code isn't run:
+    ^if __name__ == ['"]__main__['"]:$
+
+[html]
+directory = coverage-html
+
+# vim:ft=dosini

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.coverage
 *.pyc
 *.pyo
 *.swp
@@ -10,8 +11,10 @@ env
 /include/
 /lib/
 /local/
+/venv*/
 /*.egg-info/
 .ropeproject/
+.tox/
 debian
 debian-upstream/files
 debian-upstream/nodeenv.substvars

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+env: # These should match the tox env list
+    - TOXENV=py26
+    - TOXENV=py27
+    - TOXENV=py33
+    - TOXENV=py34
+    - TOXENV=pypy
+    - TOXENV=pypy3
+install: pip install coveralls tox --use-mirrors
+script: tox
+after_success:
+    - coveralls
+sudo: false

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+-e .
+
+coverage
+flake8
+mock
+pytest

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ import os
 from setuptools import setup
 from nodeenv import nodeenv_version
 
+
 def read_file(file_name):
     return open(
         os.path.join(
@@ -26,9 +27,7 @@ setup(
     license='BSD',
     author='Eugene Kalinin',
     author_email='e.v.kalinin@gmail.com',
-    install_requires = [
-        'lxml',
-    ],
+    install_requires=[],
     description="Node.js virtual environment builder",
     long_description=ldesc,
     py_modules=['nodeenv'],

--- a/tests/iojs.htm
+++ b/tests/iojs.htm
@@ -1,0 +1,24 @@
+<html>
+<head><title>Index of /dist/latest/</title></head>
+<body bgcolor="white">
+<h1>Index of /dist/latest/</h1><hr><pre><a href="../">../</a>
+<a href="doc/">doc/</a>                                               14-Jan-2015 04:43                   -
+<a href="win-x64/">win-x64/</a>                                           14-Jan-2015 04:48                   -
+<a href="win-x86/">win-x86/</a>                                           14-Jan-2015 04:45                   -
+<a href="SHASUMS256.txt">SHASUMS256.txt</a>                                     14-Jan-2015 05:04                1428
+<a href="SHASUMS256.txt.asc">SHASUMS256.txt.asc</a>                                 14-Jan-2015 05:04                1948
+<a href="SHASUMS256.txt.gpg">SHASUMS256.txt.gpg</a>                                 14-Jan-2015 05:04                2141
+<a href="iojs-v1.0.1-darwin-x64.tar.gz">iojs-v1.0.1-darwin-x64.tar.gz</a>                      14-Jan-2015 04:38             6463647
+<a href="iojs-v1.0.1-linux-armv7l.tar.gz">iojs-v1.0.1-linux-armv7l.tar.gz</a>                    14-Jan-2015 04:59             7275326
+<a href="iojs-v1.0.1-linux-armv7l.tar.xz">iojs-v1.0.1-linux-armv7l.tar.xz</a>                    14-Jan-2015 04:59             4848364
+<a href="iojs-v1.0.1-linux-x64.tar.gz">iojs-v1.0.1-linux-x64.tar.gz</a>                       14-Jan-2015 04:42             7782045
+<a href="iojs-v1.0.1-linux-x64.tar.xz">iojs-v1.0.1-linux-x64.tar.xz</a>                       14-Jan-2015 04:42             5331880
+<a href="iojs-v1.0.1-linux-x86.tar.gz">iojs-v1.0.1-linux-x86.tar.gz</a>                       14-Jan-2015 04:43             7584510
+<a href="iojs-v1.0.1-linux-x86.tar.xz">iojs-v1.0.1-linux-x86.tar.xz</a>                       14-Jan-2015 04:43             5184944
+<a href="iojs-v1.0.1-x64.msi">iojs-v1.0.1-x64.msi</a>                                14-Jan-2015 04:49             7313864
+<a href="iojs-v1.0.1-x86.msi">iojs-v1.0.1-x86.msi</a>                                14-Jan-2015 04:46             6707654
+<a href="iojs-v1.0.1.pkg">iojs-v1.0.1.pkg</a>                                    14-Jan-2015 04:41             8608836
+<a href="iojs-v1.0.1.tar.gz">iojs-v1.0.1.tar.gz</a>                                 14-Jan-2015 04:43            19056750
+<a href="iojs-v1.0.1.tar.xz">iojs-v1.0.1.tar.xz</a>                                 14-Jan-2015 04:43            11892124
+</pre><hr></body>
+</html>

--- a/tests/nodeenv_test.py
+++ b/tests/nodeenv_test.py
@@ -1,0 +1,70 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import io
+import os.path
+import subprocess
+
+import pytest
+
+from nodeenv import GetsAHrefs
+
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+
+def test_gets_a_hrefs_trivial():
+    parser = GetsAHrefs()
+    parser.feed('')
+    assert parser.hrefs == []
+
+
+def test_gets_a_hrefs_nodejs_org():
+    # Retrieved 2015-01-15
+    contents = io.open(os.path.join(HERE, 'nodejs.htm')).read()
+    parser = GetsAHrefs()
+    parser.feed(contents)
+    # Smoke test
+    assert parser.hrefs == [
+        '../', 'docs/', 'x64/', 'SHASUMS.txt', 'SHASUMS.txt.asc',
+        'SHASUMS.txt.gpg', 'SHASUMS256.txt', 'SHASUMS256.txt.asc',
+        'SHASUMS256.txt.gpg', 'node-v0.10.35-darwin-x64.tar.gz',
+        'node-v0.10.35-darwin-x86.tar.gz', 'node-v0.10.35-linux-x64.tar.gz',
+        'node-v0.10.35-linux-x86.tar.gz', 'node-v0.10.35-sunos-x64.tar.gz',
+        'node-v0.10.35-sunos-x86.tar.gz', 'node-v0.10.35-x86.msi',
+        'node-v0.10.35.pkg', 'node-v0.10.35.tar.gz', 'node.exe',
+        'node.exp', 'node.lib', 'node.pdb', 'openssl-cli.exe',
+        'openssl-cli.pdb',
+    ]
+
+
+def test_gets_a_hrefs_iojs_org():
+    # Retrieved 2015-01-15
+    contents = io.open(os.path.join(HERE, 'iojs.htm')).read()
+    parser = GetsAHrefs()
+    parser.feed(contents)
+    # Smoke test
+    assert parser.hrefs == [
+        '../', 'doc/', 'win-x64/', 'win-x86/', 'SHASUMS256.txt',
+        'SHASUMS256.txt.asc', 'SHASUMS256.txt.gpg',
+        'iojs-v1.0.1-darwin-x64.tar.gz', 'iojs-v1.0.1-linux-armv7l.tar.gz',
+        'iojs-v1.0.1-linux-armv7l.tar.xz', 'iojs-v1.0.1-linux-x64.tar.gz',
+        'iojs-v1.0.1-linux-x64.tar.xz', 'iojs-v1.0.1-linux-x86.tar.gz',
+        'iojs-v1.0.1-linux-x86.tar.xz', 'iojs-v1.0.1-x64.msi',
+        'iojs-v1.0.1-x86.msi', 'iojs-v1.0.1.pkg', 'iojs-v1.0.1.tar.gz',
+        'iojs-v1.0.1.tar.xz',
+    ]
+
+
+@pytest.mark.integration
+def test_smoke(tmpdir):
+    nenv_path = tmpdir.join('nenv').strpath
+    subprocess.check_call([
+        # Enable coverage
+        'coverage', 'run', '-p',
+        '-m', 'nodeenv', '--prebuilt', nenv_path,
+    ])
+    assert os.path.exists(nenv_path)
+    subprocess.check_call([
+        'sh', '-c', '. {0}/bin/activate && nodejs --version'.format(nenv_path),
+    ])

--- a/tests/nodejs.htm
+++ b/tests/nodejs.htm
@@ -1,0 +1,29 @@
+<html>
+<head><title>Index of /dist/latest/</title></head>
+<body bgcolor="white">
+<h1>Index of /dist/latest/</h1><hr><pre><a href="../">../</a>
+<a href="docs/">docs/</a>                                              25-Dec-2014 16:16                   -
+<a href="x64/">x64/</a>                                               22-Dec-2014 21:33                   -
+<a href="SHASUMS.txt">SHASUMS.txt</a>                                        22-Dec-2014 21:50                1359
+<a href="SHASUMS.txt.asc">SHASUMS.txt.asc</a>                                    22-Dec-2014 21:50                1649
+<a href="SHASUMS.txt.gpg">SHASUMS.txt.gpg</a>                                    22-Dec-2014 21:50                 845
+<a href="SHASUMS256.txt">SHASUMS256.txt</a>                                     22-Dec-2014 21:50                1887
+<a href="SHASUMS256.txt.asc">SHASUMS256.txt.asc</a>                                 22-Dec-2014 21:50                2177
+<a href="SHASUMS256.txt.gpg">SHASUMS256.txt.gpg</a>                                 22-Dec-2014 21:50                1159
+<a href="node-v0.10.35-darwin-x64.tar.gz">node-v0.10.35-darwin-x64.tar.gz</a>                    22-Dec-2014 21:32             5119135
+<a href="node-v0.10.35-darwin-x86.tar.gz">node-v0.10.35-darwin-x86.tar.gz</a>                    22-Dec-2014 21:29             4944714
+<a href="node-v0.10.35-linux-x64.tar.gz">node-v0.10.35-linux-x64.tar.gz</a>                     22-Dec-2014 21:32             5674318
+<a href="node-v0.10.35-linux-x86.tar.gz">node-v0.10.35-linux-x86.tar.gz</a>                     22-Dec-2014 21:32             5476680
+<a href="node-v0.10.35-sunos-x64.tar.gz">node-v0.10.35-sunos-x64.tar.gz</a>                     22-Dec-2014 21:38             6942340
+<a href="node-v0.10.35-sunos-x86.tar.gz">node-v0.10.35-sunos-x86.tar.gz</a>                     22-Dec-2014 21:38             6515411
+<a href="node-v0.10.35-x86.msi">node-v0.10.35-x86.msi</a>                              22-Dec-2014 21:48             5808128
+<a href="node-v0.10.35.pkg">node-v0.10.35.pkg</a>                                  22-Dec-2014 21:35            10279155
+<a href="node-v0.10.35.tar.gz">node-v0.10.35.tar.gz</a>                               22-Dec-2014 21:28            14417025
+<a href="node.exe">node.exe</a>                                           22-Dec-2014 21:48             5832576
+<a href="node.exp">node.exp</a>                                           22-Dec-2014 21:48              186902
+<a href="node.lib">node.lib</a>                                           22-Dec-2014 21:48              304702
+<a href="node.pdb">node.pdb</a>                                           22-Dec-2014 21:48            17574912
+<a href="openssl-cli.exe">openssl-cli.exe</a>                                    22-Dec-2014 21:48             1829888
+<a href="openssl-cli.pdb">openssl-cli.pdb</a>                                    22-Dec-2014 21:48             7457792
+</pre><hr></body>
+</html>

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,25 @@
+[tox]
+# These should match the travis env list
+envlist = py26,py27,py33,py34,pypy,pypy3
+
+[testenv]
+install_command = pip install --use-wheel {opts} {packages}
+deps = -rrequirements-dev.txt
+commands =
+    coverage erase
+    coverage run -p -m pytest {posargs:tests}
+    # Needed because we subprocess to ourselves
+    coverage combine
+    coverage report --show-missing --fail-under 55  # TODO: 100
+    flake8 nodeenv.py tests setup.py
+
+[testenv:venv]
+envdir = venv-nodeenv
+commands =
+
+[testenv:docs]
+deps =
+    {[testenv]deps}
+    sphinx
+changedir = docs
+commands = sphinx-build -b html -d build/doctrees source build/html


### PR DESCRIPTION
I ran into some issues in http://github.com/pre-commit/pre-commit-hooks with installing lxml under pypy3.  Also given that lxml is pretty heavy-weight and no deps >>> having deps I decided to factor lxml out of nodeenv.

I also added a testsuite and made it work with travis-ci... hope that's ok :)