### PR TITLE
UnicodeDecodeError when trying to build on non UTF-8 environment 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -268,7 +268,7 @@ There are several alternatives that create isolated environments:
   version.
   Can not pass additional arguments into configure (for example --without-ssl)
 
-* virtualenv_ — Virtual Python Environment builder. For python only.
+* virtualenv_ - Virtual Python Environment builder. For python only.
 
 .. _`virtualenv`: https://github.com/pypa/virtualenv
 

--- a/setup.py
+++ b/setup.py
@@ -5,17 +5,20 @@ nodeenv
 
 Node.js Virtual Environment builder.
 """
+import codecs
 import os
-from setuptools import setup
+
 from nodeenv import nodeenv_version
+from setuptools import setup
 
 
 def read_file(file_name):
-    return open(
+    return codecs.open(
         os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
             file_name
-        )
+        ),
+        encoding='utf-8',
     ).read()
 
 ldesc = read_file('README.rst')


### PR DESCRIPTION
Hi,

I got an UnicodeDecodeError trying to read README.rst when my locale was anything other than UTF-8.
I made a change to specify the encoding when opening the file. And also removed the unicode character on README.rst.

You can reproduce the error:
```
$ LC_ALL=C python3 setup.py build

Traceback (most recent call last):
  File "setup.py", line 21, in <module>
    ldesc = read_file('README.rst')
  File "setup.py", line 17, in read_file
    file_name
  File "/usr/local/Cellar/python3/3.4.3/Frameworks/Python.framework/Versions/3.4/lib/python3.4/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 7085: ordinal not in range(128)
```