### PR TITLE
use bash-builtin cd in activate script

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -988,7 +988,7 @@ if [ "${BASH_SOURCE}" ] ; then
     SOURCE="${BASH_SOURCE[0]}"
 
     while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
-    DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    DIR="$( command cd -P "$( dirname "$SOURCE" )" && pwd )"
 
     NODE_VIRTUAL_ENV="$(dirname "$DIR")"
 else


### PR DESCRIPTION
This avoids nasty interference with https://github.com/kennethreitz/autoenv and similar bash magic that aliases `cd`.