### PR TITLE
Swallow output of cd

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -1016,7 +1016,7 @@ if [ "${BASH_SOURCE}" ] ; then
     SOURCE="${BASH_SOURCE[0]}"
 
     while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
-    DIR="$( command cd -P "$( dirname "$SOURCE" )" && pwd )"
+    DIR="$( command cd -P "$( dirname "$SOURCE" )" > /dev/null && pwd )"
 
     NODE_VIRTUAL_ENV="$(dirname "$DIR")"
 else


### PR DESCRIPTION
The bash prints the directory it has changed to stdout if an option like
autocd, cdspell, dirspell or CDPATH is used. We expect no output from
this command.