### PR TITLE
README: note that python 2.6 or 2.7 is required

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Dependency
 For nodeenv
 ^^^^^^^^^^^
 
-* python (>= 2.6)
+* python (2.6 or 2.7)
 * make
 * tail
 


### PR DESCRIPTION
This is based on this detail from the node build information: https://github.com/nodejs/node/blob/33c27f8fcffd7b0c6d609fdd4503b4f7a3c45bcd/BUILDING.md

Trying to use python 3 when installing node currently does not do anything useful, hoping this can save somebody else a bit of time.