### PR TITLE
Do not append content repeatedly to activate script.

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -385,7 +385,7 @@ def writefile(dest, content, overwrite=True, append=False):
     else:
         with open(dest, 'rb') as f:
             c = f.read()
-        if c == content:
+        if content in c:
             logger.debug(' * Content %s already in place', dest)
             return
 


### PR DESCRIPTION
Check if the content is contained in the destination file, vs. identical to it.