### PR TITLE
Run deactivate_node when node is associated with the virtual environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env: # These should match the tox env list
     - TOXENV=py27
     - TOXENV=py33
     - TOXENV=py34
+    - TEXENV=py35
     - TOXENV=pypy
     - TOXENV=pypy3
 install: pip install coveralls tox --use-mirrors

--- a/nodeenv.py
+++ b/nodeenv.py
@@ -748,6 +748,11 @@ def install_activate(env_dir, opt):
         os.symlink("node", shim_nodejs)
 
 
+def set_predeactivate_hook(env_dir):
+    with open(join(env_dir, 'bin', 'predeactivate'), 'a') as hook:
+        hook.write(PREDEACTIVATE_SH)
+
+
 def create_environment(env_dir, opt):
     """
     Creates a new environment in ``env_dir``.
@@ -773,6 +778,8 @@ def create_environment(env_dir, opt):
         install_npm(env_dir, src_dir, opt)
     if opt.requirements:
         install_packages(env_dir, opt)
+    if opt.python_virtualenv:
+        set_predeactivate_hook(env_dir)
     # Cleanup
     if opt.clean_src:
         callit(['rm -rf', pipes.quote(src_dir)], opt.verbose, True, env_dir)
@@ -1068,6 +1075,10 @@ fi
 if [ -n "$BASH" -o -n "$ZSH_VERSION" ] ; then
     hash -r
 fi
+"""
+
+PREDEACTIVATE_SH = """
+if type -p deactivate_node > /dev/null; then deactivate_node;fi
 """
 
 if __name__ == '__main__':

--- a/tests/nodeenv_test.py
+++ b/tests/nodeenv_test.py
@@ -141,3 +141,16 @@ def test_print_node_versions_node(cap_logging_info):
     # 8 items per line = 7 tabs
     # The last line contains the remaning 3 items
     assert tabs_per_line == [7] * 28 + [2]
+
+
+def test_predeactivate_hook(tmpdir):
+    # Throw error if the environment directory is not a string
+    with pytest.raises((TypeError, AttributeError)):
+        nodeenv.set_predeactivate_hook(tmpdir)
+    # Throw error if environment directory has no bin path
+    with pytest.raises((OSError, IOError)):
+        nodeenv.set_predeactivate_hook(tmpdir.strpath)
+    tmpdir.mkdir('bin')
+    nodeenv.set_predeactivate_hook(tmpdir.strpath)
+    p = tmpdir.join('bin').join('predeactivate')
+    assert 'deactivate_node' in p.read()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # These should match the travis env list
-envlist = py26,py27,py33,py34,pypy,pypy3
+envlist = py26,py27,py33,py34,py35,pypy,pypy3
 
 [testenv]
 install_command = pip install --use-wheel {opts} {packages}


### PR DESCRIPTION
When nodeenv is run with -p, I think it's a lesser surprise if node is deactivated too when the virtualenv is deactivated.

As it is right now, nodeenv's environment variables (and the deactivate_node command itself) remain in the path even when one disables the virtual environment.

Basically what #99 is about.