### PR TITLE
Fix Windows support for installing node and npm from prebuilt

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -564,7 +564,7 @@ def copy_node_from_prebuilt(env_dir, src_dir):
     if is_WIN:
         callit(['copy', '/Y', '/L', join(src_dir, 'node.exe'), join(env_dir, 'Scripts', 'node.exe')], False, True)
     else:
-        callit(['cp', '-a', join(src_dir, '/%s-v*/*' % prefix), env_dir], True, env_dir)
+        callit(['cp', '-a', src_dir + '/%s-v*/*' % prefix, env_dir], True, env_dir)
     logger.info('.', extra=dict(continued=True))
 
 


### PR DESCRIPTION
* This commit disables support for building from source *under Windows*
  altogether as we cannot really rely on a fixed environment (like gcc,
  make, etc) being present on Windows. I may add that support in the
  future

* Under Windows, we need to always download npm seperately as it doesn't
  come bundled with the node.exe that we use.

* Activation scripts are copied verbatim from
  ekalinin/nodeenv@windows-support

* Using the node system version is not supported under Windows as we have
  no reliable way of knowing where it is installed