### PR TITLE
Do not fail if nodejs link can't be created on Windows

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -810,7 +810,10 @@ def install_activate(env_dir, opt):
 
     if not os.path.exists(shim_nodejs):
         if is_WIN:
-            callit(['mklink', shim_nodejs, 'node.exe'], True, True)
+            try:
+                callit(['mklink', shim_nodejs, 'node.exe'], True, True)
+            except OSError:
+                logger.error('Error: Failed to create nodejs.exe link')
         else:
             os.symlink("node", shim_nodejs)
 


### PR DESCRIPTION
Final fix for #140. `mklink` fails with
`You do not have sufficient privilege to perform this operation.`
on my system, so make it optional.