### PR TITLE
Fix bug when downgrading using --force

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -559,7 +559,7 @@ def urlopen(url):
 # Virtual environment functions
 
 
-def copy_node_from_prebuilt(env_dir, src_dir):
+def copy_node_from_prebuilt(env_dir, src_dir, node_version):
     """
     Copy prebuilt binaries into environment
     """
@@ -571,7 +571,7 @@ def copy_node_from_prebuilt(env_dir, src_dir):
         mkdir(join(env_dir, 'Scripts'))
         callit(['copy', '/Y', '/L', src_exe, dst_exe], False, True)
     else:
-        src_folder = src_dir + '/%s-v*/*' % prefix
+        src_folder = src_dir + '/%s-v%s*/*' % (prefix, node_version)
         callit(['cp', '-a', src_folder, env_dir], True, env_dir)
     logger.info('.', extra=dict(continued=True))
 
@@ -660,7 +660,7 @@ def install_node(env_dir, src_dir, opt):
     logger.info('.', extra=dict(continued=True))
 
     if opt.prebuilt:
-        copy_node_from_prebuilt(env_dir, src_dir)
+        copy_node_from_prebuilt(env_dir, src_dir, opt.node)
     else:
         build_node_from_src(env_dir, src_dir, node_src_dir, opt)
 


### PR DESCRIPTION
Fixes #182.

The bug was present due to the behavior of `cp -a` and [a loose wildcard path specifier here](https://github.com/ekalinin/nodeenv/blob/master/nodeenv.py#L574). If you downloaded a prebuilt Node and created a virtualenv using it, then downloaded a lower-versioned Node and tried to overwrite (downgrade) your existing virtualenv using it, both versions of node would still be in the `<env_dir>/src` directory, and nodeenv would copy _both_ when creating the second nodeenv. The one with the higher version number would be copied second, meaning the version of node in the second nodeenv would still be the higher version of node you didn't want.

Fixed by passing the desired node version to the `copy_node_from_prebuilt` method and narrowing the glob specifier to only copy that version.