### PR TITLE
Add py36 environment to CI and fix test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env: # These should match the tox env list
     - TOXENV=py33
     - TOXENV=py34
     - TOXENV=py35
+    - TOXENV=py36
     - TOXENV=pypy
 install: pip install coveralls tox
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: python
-python: 3.5
-env: # These should match the tox env list
-    - TOXENV=py27
-    - TOXENV=py33
-    - TOXENV=py34
-    - TOXENV=py35
-    - TOXENV=py36
-    - TOXENV=pypy
-install: pip install coveralls tox
+python:
+    - 2.7
+    - 3.3
+    - 3.4
+    - 3.5
+    - 3.6
+    - pypy
+install: pip install coveralls tox-travis
 script: tox
 after_success:
     - coveralls

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries :: Python Modules'

--- a/tests/nodeenv_test.py
+++ b/tests/nodeenv_test.py
@@ -146,7 +146,7 @@ def test_print_node_versions_node(cap_logging_info):
 def test_predeactivate_hook(tmpdir):
     # Throw error if the environment directory is not a string
     with pytest.raises((TypeError, AttributeError)):
-        nodeenv.set_predeactivate_hook(tmpdir)
+        nodeenv.set_predeactivate_hook(1)
     # Throw error if environment directory has no bin path
     with pytest.raises((OSError, IOError)):
         nodeenv.set_predeactivate_hook(tmpdir.strpath)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # These should match the travis env list
-envlist = py27,py33,py34,py35,pypy
+envlist = py27,py33,py34,py35,py36,pypy
 
 [testenv]
 install_command = pip install --use-wheel {opts} {packages}


### PR DESCRIPTION
`test_predeactivate_hook` fails on `py36` because `tmpdir` (`py.local`)
implements the `__path__` protocol so the call to open inside
`nodeenv.set_predeactivate_hook actually` goes through but fails
with an `FileNotFoundError` instead of the expected `TypeError`.