### PR TITLE
Add "activate.fish" script for fish shell support

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -810,7 +810,11 @@ def install_activate(env_dir, opt):
         shim_node = join(bin_dir, "node.exe")
         shim_nodejs = join(bin_dir, "nodejs.exe")
     else:
-        files = {'activate': ACTIVATE_SH, 'shim': SHIM}
+        files = {
+            'activate': ACTIVATE_SH,
+            'activate.fish': ACTIVATE_FISH,
+            'shim': SHIM
+        }
         bin_dir = join(env_dir, 'bin')
         shim_node = join(bin_dir, "node")
         shim_nodejs = join(bin_dir, "nodejs")
@@ -1241,7 +1245,7 @@ freeze () {
     fi
 }
 
-# unset irrelavent variables
+# unset irrelevant variables
 deactivate_node nondestructive
 
 # find the directory of this script
@@ -1300,6 +1304,136 @@ if [ -n "$BASH" -o -n "$ZSH_VERSION" ] ; then
     hash -r
 fi
 """
+
+
+ACTIVATE_FISH = """
+
+# This file must be used with "source bin/activate.fish" *from fish*
+# you cannot run it directly
+
+function deactivate_node -d 'Exit nodeenv and return to normal environment.'
+    # reset old environment variables
+    if test -n "$_OLD_NODE_VIRTUAL_PATH"
+        set -gx PATH $_OLD_NODE_VIRTUAL_PATH
+        set -e _OLD_NODE_VIRTUAL_PATH
+    end
+
+    if test -n "$_OLD_NODE_PATH"
+        set -gx NODE_PATH $_OLD_NODE_PATH
+        set -e _OLD_NODE_PATH
+    else
+        set -e NODE_PATH
+    end
+
+    if test -n "$_OLD_NPM_CONFIG_PREFIX"
+        set -gx NPM_CONFIG_PREFIX $_OLD_NPM_CONFIG_PREFIX
+        set -e _OLD_NPM_CONFIG_PREFIX
+    else
+        set -e NPM_CONFIG_PREFIX
+    end
+
+    if test -n "$_OLD_npm_config_prefix"
+        set -gx npm_config_prefix $_OLD_npm_config_prefix
+        set -e _OLD_npm_config_prefix
+    else
+        set -e npm_config_prefix
+    end
+
+    if test -n "$_OLD_NODE_FISH_PROMPT_OVERRIDE"
+        # Set an empty local `$fish_function_path` to allow the removal of
+        # `fish_prompt` using `functions -e`.
+        set -l fish_function_path
+
+        # Erase virtualenv's `fish_prompt` and restore the original.
+        functions -e fish_prompt
+        functions -c _old_fish_prompt fish_prompt
+        functions -e _old_fish_prompt
+        set -e _OLD_NODE_FISH_PROMPT_OVERRIDE
+    end
+
+    if test (count $argv) = 0 -o "$argv[1]" != "nondestructive"
+        # Self destruct!
+        functions -e deactivate_node
+    end
+end
+
+function freeze -d 'Show a list of installed packages - like `pip freeze`'
+    set -l NPM_VER (npm -v | cut -d '.' -f 1)
+    set -l RE "[a-zA-Z0-9\.\-]+@[0-9]+\.[0-9]+\.[0-9]+([\+\-][a-zA-Z0-9\.\-]+)*"
+
+    if test "$NPM_VER" = "0"
+        set -g NPM_LIST (npm list installed active >/dev/null ^/dev/null | \
+                         cut -d ' ' -f 1 | grep -v npm)
+    else
+        set -l NPM_LS "npm ls -g"
+        if test (count $argv) -gt 0 -a "$argv[1]" = "-l"
+            set NPM_LS "npm ls"
+            set -e argv[1]
+        end
+        set -l NPM_LIST (eval $NPM_LS | grep -E '^.{4}\w{1}' | \
+                                        grep -o -E "$re" | \
+                                        grep -v npm)
+    end
+
+    if test (count $argv) = 0
+        echo $NPM_LIST
+    else
+        echo $NPM_LIST > $argv[1]
+    end
+end
+
+# unset irrelevant variables
+deactivate_node nondestructive
+
+# NODE_VIRTUAL_ENV is the parent of the directory where this script is
+set -gx NODE_VIRTUAL_ENV __NODE_VIRTUAL_ENV__
+
+set -gx _OLD_NODE_VIRTUAL_PATH $PATH
+# The node_modules/.bin path doesn't exists and it will print a warning, and
+# that's why we redirect stderr to /dev/null :)
+set -gx PATH "$NODE_VIRTUAL_ENV/lib/node_modules/.bin" "$NODE_VIRTUAL_ENV/__BIN_NAME__" $PATH ^/dev/null
+
+if set -q NODE_PATH
+    set -gx _OLD_NODE_PATH $NODE_PATH
+    set -gx NODE_PATH "$NODE_VIRTUAL_ENV/__MOD_NAME__" $NODE_PATH
+else
+    set -gx NODE_PATH "$NODE_VIRTUAL_ENV/__MOD_NAME__"
+end
+
+if set -q NPM_CONFIG_PREFIX
+    set -gx _OLD_NPM_CONFIG_PREFIX $NPM_CONFIG_PREFIX
+end
+set -gx NPM_CONFIG_PREFIX "__NPM_CONFIG_PREFIX__"
+
+if set -q npm_config_prefix
+    set -gx _OLD_npm_config_prefix $npm_config_prefix
+end
+set -gx npm_config_prefix "__NPM_CONFIG_PREFIX__"
+
+if test -z "$NODE_VIRTUAL_ENV_DISABLE_PROMPT"
+    # Copy the current `fish_prompt` function as `_old_fish_prompt`.
+    functions -c fish_prompt _old_fish_prompt
+
+    function fish_prompt
+        # Save the current $status, for fish_prompts that display it.
+        set -l old_status $status
+
+        # Prompt override provided?
+        # If not, just prepend the environment name.
+        if test -n ""
+            printf '%s%s' "" (set_color normal)
+        else
+            printf '%s(%s) ' (set_color normal) (basename "$NODE_VIRTUAL_ENV")
+        end
+
+        # Restore the original $status
+        echo "exit $old_status" | source
+        _old_fish_prompt
+    end
+
+    set -gx _OLD_NODE_FISH_PROMPT_OVERRIDE "$NODE_VIRTUAL_ENV"
+end
+"""  # noqa
 
 PREDEACTIVATE_SH = """
 if type -p deactivate_node > /dev/null; then deactivate_node;fi


### PR DESCRIPTION
As the title says, this PR add the script `activate.fish` to support the fish shell.

I don't know if a `shim.fish` script should be added as I'm not really sure what's its purpose, if someone can provide me some guidance I have no problem adding it to the PR.
Also I don't know how to add tests, as `make` doesn't work with a fish shell, ideas for testing are very welcome 😄 