### PR TITLE
Conda support

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -1010,7 +1010,7 @@ def get_env_dir(opt, args):
     if opt.python_virtualenv:
         if hasattr(sys, 'real_prefix'):
             res = sys.prefix
-        elif hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix:
+        elif hasattr(sys, 'base_prefix') and (sys.base_prefix != sys.prefix or 'CONDA_PREFIX' in os.environ):
             res = sys.prefix
         else:
             logger.error('No python virtualenv is available')

--- a/nodeenv.py
+++ b/nodeenv.py
@@ -1010,7 +1010,9 @@ def get_env_dir(opt, args):
     if opt.python_virtualenv:
         if hasattr(sys, 'real_prefix'):
             res = sys.prefix
-        elif hasattr(sys, 'base_prefix') and (sys.base_prefix != sys.prefix or 'CONDA_PREFIX' in os.environ):
+        elif hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix:
+            res = sys.prefix
+        elif 'CONDA_PREFIX' in os.environ:
             res = sys.prefix
         else:
             logger.error('No python virtualenv is available')


### PR DESCRIPTION
The present options for autodetecting virtual environments (-p switch) work for virtualenv and venv, but not conda, which sets `sys.base_prefix` and changes `sys.prefix` to the same value as `sys.base_prefix`.

My fix also checks if the environment variable `CONDA_PREFIX` is set and uses `base_prefix` as the environment directory in that case.