### PR TITLE
Add a space before the normal $PS1.

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -1294,14 +1294,14 @@ export npm_config_prefix
 if [ -z "$NODE_VIRTUAL_ENV_DISABLE_PROMPT" ] ; then
     _OLD_NODE_VIRTUAL_PS1="$PS1"
     if [ "x__NODE_VIRTUAL_PROMPT__" != x ] ; then
-        PS1="__NODE_VIRTUAL_PROMPT__$PS1"
+        PS1="__NODE_VIRTUAL_PROMPT__ $PS1"
     else
     if [ "`basename \"$NODE_VIRTUAL_ENV\"`" = "__" ] ; then
         # special case for Aspen magic directories
         # see http://www.zetadev.com/software/aspen/
         PS1="[`basename \`dirname \"$NODE_VIRTUAL_ENV\"\``] $PS1"
     else
-        PS1="(`basename \"$NODE_VIRTUAL_ENV\"`)$PS1"
+        PS1="(`basename \"$NODE_VIRTUAL_ENV\"`) $PS1"
     fi
     fi
     export PS1


### PR DESCRIPTION
This matches the outwards behavior of how the name of
the virtualenv normally appears.