### PR TITLE
fix npm_url in install_npm_win

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -755,7 +755,7 @@ def install_npm_win(env_dir, src_dir, opt):
     """
     logger.info(' * Install npm.js (%s) ... ' % opt.npm,
                 extra=dict(continued=True))
-    npm_url = 'https://github.com/npm/cli/archive/%s.zip' % opt.npm
+    npm_url = 'https://github.com/npm/cli/archive/v%s.zip' % opt.npm
     npm_contents = io.BytesIO(urlopen(npm_url).read())
 
     bin_path = join(env_dir, 'Scripts')


### PR DESCRIPTION
Invoking nodeenv with an explicit version of npm (`--npm=6.8.0`) failed on Windows because the archive URL was set to https://github.com/npm/cli/archive/6.8.0.zip rather than https://github.com/npm/cli/archive/v6.8.0.zip:

```
λ nodeenv --verbose testenv --node=11.10.0 --with-npm --npm=6.8.0 --prebuilt
 * Install prebuilt node (11.10.0) ..... done.
symbolic link created for testenv\Scripts\nodejs.exe <<===>> node.exe
 * Install npm.js (6.8.0) ... Traceback (most recent call last):
  File "C:\Users\smpsn\Development\nodeenv\nodeenv.py", line 1496, in <module>
    main()
  File "C:\Users\smpsn\Development\nodeenv\nodeenv.py", line 1092, in main
    create_environment(env_dir, opt)
  File "C:\Users\smpsn\Development\nodeenv\nodeenv.py", line 932, in create_environment
    instfunc(env_dir, src_dir, opt)
  File "C:\Users\smpsn\Development\nodeenv\nodeenv.py", line 759, in install_npm_win
    npm_contents = io.BytesIO(urlopen(npm_url).read())
  File "C:\Users\smpsn\Development\nodeenv\nodeenv.py", line 574, in urlopen
    return urllib2.urlopen(req)
  File "C:\Python37\lib\urllib\request.py", line 222, in urlopen
    return opener.open(url, data, timeout)
  File "C:\Python37\lib\urllib\request.py", line 531, in open
    response = meth(req, response)
  File "C:\Python37\lib\urllib\request.py", line 641, in http_response
    'http', request, response, code, msg, hdrs)
  File "C:\Python37\lib\urllib\request.py", line 563, in error
    result = self._call_chain(*args)
  File "C:\Python37\lib\urllib\request.py", line 503, in _call_chain
    result = func(*args)
  File "C:\Python37\lib\urllib\request.py", line 755, in http_error_302
    return self.parent.open(new, timeout=req.timeout)
  File "C:\Python37\lib\urllib\request.py", line 531, in open
    response = meth(req, response)
  File "C:\Python37\lib\urllib\request.py", line 641, in http_response
    'http', request, response, code, msg, hdrs)
  File "C:\Python37\lib\urllib\request.py", line 569, in error
    return self._call_chain(*args)
  File "C:\Python37\lib\urllib\request.py", line 503, in _call_chain
    result = func(*args)
  File "C:\Python37\lib\urllib\request.py", line 649, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 404: Not Found
```
Using `--npm=v6.8.0` would also fail, because after unzipping the archive nodeenv would attempt to access `cli-v6.8.0` rather than the correct directory `cli-6.8.0`:

```
λ nodeenv --verbose testenv --node=11.10.0 --with-npm --npm=v6.8.0 --prebuilt
 * Install prebuilt node (11.10.0) ..... done.
symbolic link created for testenv\Scripts\nodejs.exe <<===>> node.exe
 * Install npm.js (v6.8.0) ... Traceback (most recent call last):
  File "C:\Users\smpsn\Development\nodeenv\nodeenv.py", line 1496, in <module>
    main()
  File "C:\Users\smpsn\Development\nodeenv\nodeenv.py", line 1092, in main
    create_environment(env_dir, opt)
  File "C:\Users\smpsn\Development\nodeenv\nodeenv.py", line 932, in create_environment
    instfunc(env_dir, src_dir, opt)
  File "C:\Users\smpsn\Development\nodeenv\nodeenv.py", line 777, in install_npm_win
    shutil.copytree(join(src_dir, npm_ver), node_modules_path)
  File "C:\Python37\lib\shutil.py", line 315, in copytree
    names = os.listdir(src)
FileNotFoundError: [WinError 3] The system cannot find the path specified: 'C:\\Users\\smpsn\\Development\\nodeenv\\testenv\\src\\cli-v6.8.0'
```
I just added the `v`.