### PR TITLE
Spit out a blank line when install_node fails

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -690,6 +690,14 @@ def install_node(env_dir, src_dir, opt):
     Download source code for node.js, unpack it
     and install it in virtual environment.
     """
+    try:
+        install_node_wrapped(env_dir, src_dir, opt)
+    except:
+        # this restores the newline suppressed by continued=True
+        logger.info()
+        raise
+
+def install_node_wrapped(env_dir, src_dir, opt):
     env_dir = abspath(env_dir)
     prefix = get_binary_prefix()
     node_src_dir = join(src_dir, to_utf8('%s-v%s' % (prefix, opt.node)))


### PR DESCRIPTION
The logger is configured to suppress newlines with continued=True.
This extra logging call undoes that.

#235