### PR TITLE
Support for Git-bash on Windows.

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -26,6 +26,7 @@ import platform
 import zipfile
 import shutil
 import glob
+import psutil
 
 try:  # pragma: no cover (py2 only)
     from ConfigParser import SafeConfigParser as ConfigParser
@@ -52,8 +53,16 @@ is_PY3 = sys.version_info[0] == 3
 if is_PY3:
     from functools import cmp_to_key
 
-is_WIN = platform.system() == 'Windows'
 is_CYGWIN = platform.system().startswith('CYGWIN')
+if platform.system() == 'Windows':
+    is_WIN = True
+    # if a bash terminal is used in the process of activating this script, install as CYGWIN
+    proc_parent = psutil.Process(os.getpid()).parent()
+    while proc_parent is not None and proc_parent.name() != 'bash.exe':
+        proc_parent = proc_parent.parent()
+    if proc_parent is not None and proc_parent.name() == 'bash.exe':
+        is_WIN = False
+        is_CYGWIN = True
 
 
 # ---------------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,9 @@ setup(
     license='BSD',
     author='Eugene Kalinin',
     author_email='e.v.kalinin@gmail.com',
-    install_requires=[],
+    install_requires=[
+        'psutil'
+    ],
     description="Node.js virtual environment builder",
     long_description=ldesc,
     py_modules=['nodeenv'],


### PR DESCRIPTION
This is the only method I could think of for detecting if a user is in a bash environment on a Windows machine - and thus the best solution I could think of to issue #226 .

I've made it so that if the user is on a Windows machine, it will check whether they are running nodeenv from a bash.exe terminal (such as git-bash).  This is being done using **psutil** to check the name of all parent processes and run/install/treat as CYGWIN instead of as Windows if a bash.exe process is detected among these parent processes.

Please let me know what you think of this solution.