### PR TITLE
nodeenv is a pure python package, produce py2.py3 wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,5 +58,6 @@ setup(
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries :: Python Modules'
-    ]
+    ],
+    options={'bdist_wheel': {'universal': True}},
 )


### PR DESCRIPTION
wheels are ~slightly faster to install than installing from source

when upload a new release could you provide wheels as well?

assuming you currently promote a release using:

```bash
python setup.py sdist
twine upload -r pypi dist/*
```

additionally promoting wheels is as easy as doing:

```bash
# assumes you have `wheel` installed to the python you're using to promote
python setup.py sdist bdist_wheel
twine upload -r pypi dist/*
```