### PR TITLE
Fix call to logger.info(...)

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -700,7 +700,7 @@ def install_node(env_dir, src_dir, opt):
         install_node_wrapped(env_dir, src_dir, opt)
     except BaseException:
         # this restores the newline suppressed by continued=True
-        logger.info()
+        logger.info('')
         raise
 
 


### PR DESCRIPTION
with this diff:

```diff
$ git diff
diff --git a/nodeenv.py b/nodeenv.py
index 769bae6..dbbdaf6 100755
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -697,6 +697,7 @@ def install_node(env_dir, src_dir, opt):
     and install it in virtual environment.
     """
     try:
+        raise AssertionError('foo')
         install_node_wrapped(env_dir, src_dir, opt)
     except:
         # this restores the newline suppressed by continued=True
```

I get the following:

```console
$ ~/opt/venv/bin/python nodeenv.py  nenv
Traceback (most recent call last):
  File "nodeenv.py", line 700, in install_node
    raise AssertionError('foo')
AssertionError: foo

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "nodeenv.py", line 1517, in <module>
    main()
  File "nodeenv.py", line 1113, in main
    create_environment(env_dir, opt)
  File "nodeenv.py", line 936, in create_environment
    install_node(env_dir, src_dir, opt)
  File "nodeenv.py", line 704, in install_node
    logger.info()
TypeError: info() missing 1 required positional argument: 'msg'
```

this patch fixes this