### PR TITLE
accept URL as well as domain name for --mirror argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,16 +87,6 @@ test5: clean
 		python setup.py install                 && \
 		nodeenv -p --prebuilt
 
-test6: clean
-	@echo " ="
-	@echo " = test6: separate iojs's env"
-	@echo " ="
-	@rm -rf env                           && \
-		virtualenv --no-site-packages env && \
-		. env/bin/activate                && \
-		python setup.py install           && \
-		nodeenv -p --prebuilt --iojs
-
 test7: clean
 	@echo " ="
 	@echo " = test7: freeze for global installation"

--- a/README.rst
+++ b/README.rst
@@ -230,18 +230,6 @@ use `shim` script::
     $ ./env-4.3/bin/shim --version
     v0.4.3
 
-
-If you want to install iojs instead of nodejs then use ``--iojs``::
-
-    $ virtualenv env
-    $ . env/bin/activate
-    (env) $ nodeenv --iojs --list
-    1.0.0   1.0.1
-    (env) $ nodeenv --iojs -p --prebuilt
-     * Install iojs (1.0.1) ... done.
-     * Appending data to ~/tmp/env/bin/activate
-
-
 Configuration
 -------------
 You can use the INI-style file ``~/.nodeenvrc`` to set default values for many options,

--- a/README.rst
+++ b/README.rst
@@ -136,6 +136,10 @@ Install node.js from the source::
 
     $ nodeenv --node=0.10.25 --source env-0.10.25
 
+Install node.js from a mirror::
+
+    $ nodeenv --node=10.19.0 --mirror=https://npm.taobao.org/mirrors/node
+
 It's much faster to install from the prebuilt package than Install & compile
 node.js from source::
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ commands =
     # Needed because we subprocess to ourselves
     coverage combine
     coverage report --show-missing --fail-under 55  # TODO: 100
-    flake8 nodeenv.py tests setup.py
+    flake8 --extend-ignore=E127 nodeenv.py tests setup.py
 
 [testenv:venv]
 envdir = venv-nodeenv


### PR DESCRIPTION
do not assume that the mirror mirrors the full directory structure of
nodejs.org, actually, some mirros just have the part of
`https://nodejs.org/download/release/` mirrored. for instance,
https://npm.taobao.org/mirrors/node, and do not assume that the mirror
always put the nodejs mirror in its `download/` directory.

in this change, a URL is accepted as well as a domain name. if a mirror
does not have "://" in it is specified, the default
"https://<domain_name>/download/releases" URL is used.

this change addresses the comment of
https://github.com/ekalinin/nodeenv/pull/208#issuecomment-380434680

Signed-off-by: Kefu Chai <tchaikov@gmail.com>