### PR TITLE
Ignore SSL Certs for MITM/Firewalls

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -343,7 +343,7 @@ def parse_args(check=True):
     parser.add_option(
         '--ignore_ssl_certs', dest='ignore_ssl_certs',
         action='store_true', default=Config.ignore_ssl_certs,
-        help='Ignore certificates for package downloads - UNSAFE - (See ssl.SSLContext.verify_mode).')
+        help='Ignore certificates for package downloads. - UNSAFE -')
 
     options, args = parser.parse_args()
 
@@ -586,8 +586,7 @@ def urlopen(url):
         context = ssl.SSLContext()
         context.verify_mode = ssl.CERT_NONE
         return urllib2.urlopen(req, context=context)
-    else:
-        return urllib2.urlopen(req)
+    return urllib2.urlopen(req)
 
 # ---------------------------------------------------------
 # Virtual environment functions


### PR DESCRIPTION
Adding option "--ignore_ssl_certs" to set ssl.SSLContext.verify_mode=ssl.CERT_NONE

This is "UNSAFE" but allows users behind corporate firewalls to bypass SSL Certificate errors from urllib.urlopen due to MITM situations.

I've written and tested these changes behind a corporate firewall on WSL (Windows Subsystems for Linux) Ubuntu 18.04 using Python 3.6 in a virtual environment.