### PR TITLE
Improve quoting of varibles in the node shim for -n system

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -1074,10 +1074,10 @@ set -e NODE_VIRTUAL_ENV_DISABLE_PROMPT
 }
 
 SHIM = """#!/usr/bin/env bash
-export NODE_PATH=__NODE_VIRTUAL_ENV__/lib/node_modules
-export NPM_CONFIG_PREFIX=__NODE_VIRTUAL_ENV__
-export npm_config_prefix=__NODE_VIRTUAL_ENV__
-exec __SHIM_NODE__ "$@"
+export NODE_PATH='__NODE_VIRTUAL_ENV__/lib/node_modules'
+export NPM_CONFIG_PREFIX='__NODE_VIRTUAL_ENV__'
+export npm_config_prefix='__NODE_VIRTUAL_ENV__'
+exec '__SHIM_NODE__' "$@"
 """
 
 ACTIVATE_BAT = r"""

--- a/tests/nodeenv_test.py
+++ b/tests/nodeenv_test.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import os.path
+import pipes
 import subprocess
 import sys
 
@@ -23,8 +24,24 @@ def test_smoke(tmpdir):
         '-m', 'nodeenv', '--prebuilt', nenv_path,
     ])
     assert os.path.exists(nenv_path)
+    activate = pipes.quote(os.path.join(nenv_path, 'bin', 'activate'))
     subprocess.check_call([
-        'sh', '-c', '. {0}/bin/activate && nodejs --version'.format(nenv_path),
+        'sh', '-c', '. {} && nodejs --version'.format(activate),
+    ])
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(sys.platform == 'win32', reason='-n system is posix only')
+def test_smoke_n_system_special_chars(tmpdir):
+    nenv_path = tmpdir.join('nenv (production env)').strpath
+    subprocess.check_call((
+        'coverage', 'run', '-p',
+        '-m', 'nodeenv', '-n', 'system', nenv_path,
+    ))
+    assert os.path.exists(nenv_path)
+    activate = pipes.quote(os.path.join(nenv_path, 'bin', 'activate'))
+    subprocess.check_call([
+        'sh', '-c', '. {} && nodejs --version'.format(activate),
     ])
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,3 +25,7 @@ deps =
     sphinx
 changedir = docs
 commands = sphinx-build -b html -d build/doctrees source build/html
+
+[pytest]
+markers =
+    integration: tests that take a little bit longer


### PR DESCRIPTION
- this isn't quite perfect, for example a node environment containaing a
  single quote character will still produce problems.  but this is an
  improvement
- a more thorough approach would be to use `shlex.quote` -- however I'm not
  100% certain how that would interact with other shells and particularly
  windows

Resolves pre-commit/pre-commit#1483