### PR TITLE
tests: support python releases before 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: python
 python:
     - 2.7
-    - 3.4
-    - 3.5
     - 3.6
+    - 3.7
     - pypy
 install: pip install coveralls tox-travis
 script: tox

--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ Dependency
 For nodeenv
 ^^^^^^^^^^^
 
-* python (2.6+, 3.3+, or pypy)
+* python (2.6+, 3.5+, or pypy)
 * make
 * tail
 

--- a/tests/nodeenv_test.py
+++ b/tests/nodeenv_test.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import os.path
 import pipes
+import shutil
 import subprocess
 import sys
 import sysconfig
@@ -15,11 +16,15 @@ import nodeenv
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
-
-if subprocess.run(["which", "nodejs"],capture_output=True).returncode == 0:
-    is_nodejs = True
-else:
-    is_nodejs = False
+try:
+    is_nodejs = shutil.which("nodejs") is not None
+except AttributeError:
+    try:
+        subprocess.check_call(["which", "nodejs"], stdout=subprocess.PIPE)
+    except subprocess.CalledProcessError:
+        is_nodejs = False
+    else:
+        is_nodejs = True
 
 
 def call_nodejs(ev_path):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # These should match the travis env list
-envlist = py27,py34,py35,py36,pypy
+envlist = py27,py36,py37,pypy
 
 [testenv]
 install_command = pip install {opts} {packages}


### PR DESCRIPTION
the "capture_output" parameter of subprocess.run() was introduced in
python3.7. so should not rely on this feature unless we drop the support
of python2 and python3.6

Signed-off-by: Kefu Chai <tchaikov@gmail.com>