### PR TITLE
Fix nodeenv prompt when using Fish

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -1436,8 +1436,8 @@ if test -z "$NODE_VIRTUAL_ENV_DISABLE_PROMPT"
 
         # Prompt override provided?
         # If not, just prepend the environment name.
-        if test -n ""
-            printf '%s%s' "" (set_color normal)
+        if test -n "__NODE_VIRTUAL_PROMPT__"
+            printf '%s%s ' "__NODE_VIRTUAL_PROMPT__" (set_color normal)
         else
             printf '%s(%s) ' (set_color normal) (basename "$NODE_VIRTUAL_ENV")
         end


### PR DESCRIPTION
When creating a node environment with `nodeenv --prompt="(special)" nenv`, the prompt value is ignored in `activate.fish` due to some missing template strings. This PR fixes it.