### PR TITLE
use node instead of nodejs

### DIFF
--- a/tests/nodeenv_test.py
+++ b/tests/nodeenv_test.py
@@ -27,7 +27,7 @@ def test_smoke(tmpdir):
     assert os.path.exists(nenv_path)
     activate = pipes.quote(os.path.join(nenv_path, 'bin', 'activate'))
     subprocess.check_call([
-        'sh', '-c', '. {} && nodejs --version'.format(activate),
+        'sh', '-c', '. {} && node --version'.format(activate),
     ])
 
 
@@ -42,7 +42,7 @@ def test_smoke_n_system_special_chars(tmpdir):
     assert os.path.exists(nenv_path)
     activate = pipes.quote(os.path.join(nenv_path, 'bin', 'activate'))
     subprocess.check_call([
-        'sh', '-c', '. {} && nodejs --version'.format(activate),
+        'sh', '-c', '. {} && node --version'.format(activate),
     ])
 
 

--- a/tests/nodeenv_test.py
+++ b/tests/nodeenv_test.py
@@ -16,25 +16,6 @@ import nodeenv
 HERE = os.path.abspath(os.path.dirname(__file__))
 
 
-if subprocess.run(["which", "nodejs"],capture_output=True).returncode == 0:
-    is_nodejs = True
-else:
-    is_nodejs = False
-
-
-def call_nodejs(ev_path):
-    assert os.path.exists(ev_path)
-    activate = pipes.quote(os.path.join(ev_path, 'bin', 'activate'))
-    if is_nodejs:
-        subprocess.check_call([
-            'sh', '-c', '. {} && nodejs --version'.format(activate),
-        ])
-    else:
-        subprocess.check_call([
-            'sh', '-c', '. {} && node --version'.format(activate),
-        ])
-
-
 @pytest.mark.integration
 def test_smoke(tmpdir):
     nenv_path = tmpdir.join('nenv').strpath
@@ -43,7 +24,11 @@ def test_smoke(tmpdir):
         'coverage', 'run', '-p',
         '-m', 'nodeenv', '--prebuilt', nenv_path,
     ])
-    call_nodejs(nenv_path)
+    assert os.path.exists(nenv_path)
+    activate = pipes.quote(os.path.join(nenv_path, 'bin', 'activate'))
+    subprocess.check_call([
+        'sh', '-c', '. {} && nodejs --version'.format(activate),
+    ])
 
 
 @pytest.mark.integration
@@ -54,7 +39,11 @@ def test_smoke_n_system_special_chars(tmpdir):
         'coverage', 'run', '-p',
         '-m', 'nodeenv', '-n', 'system', nenv_path,
     ))
-    call_nodejs(nenv_path)
+    assert os.path.exists(nenv_path)
+    activate = pipes.quote(os.path.join(nenv_path, 'bin', 'activate'))
+    subprocess.check_call([
+        'sh', '-c', '. {} && nodejs --version'.format(activate),
+    ])
 
 
 @pytest.yield_fixture


### PR DESCRIPTION
`node` is the more standard binary

this reverts #270 which broke the testsuite CC @a16bitsysop