### PR TITLE
Resolve venv dir for Fish

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -1401,8 +1401,17 @@ end
 # unset irrelevant variables
 deactivate_node nondestructive
 
-# NODE_VIRTUAL_ENV is the parent of the directory where this script is
-set -gx NODE_VIRTUAL_ENV __NODE_VIRTUAL_ENV__
+# find the directory of this script
+begin
+    set -l SOURCE (status filename)
+    while test -L "$SOURCE"
+        set SOURCE (readlink "$SOURCE")
+    end
+    set -l DIR (dirname (realpath "$SOURCE"))
+
+    # NODE_VIRTUAL_ENV is the parent of the directory where this script is
+    set -gx NODE_VIRTUAL_ENV (dirname "$DIR")
+end
 
 set -gx _OLD_NODE_VIRTUAL_PATH $PATH
 # The node_modules/.bin path doesn't exists and it will print a warning, and


### PR DESCRIPTION
Moving the node venv breaks the venv when using Fish, but it is possible to resolve the script directory at runtime (similar to Bash), so we should do that automatically.