### PR TITLE
Add support for installing latest LTS release

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -226,6 +226,7 @@ def parse_args(check=True):
         '--node=0.4.3 will use the node-v0.4.3 '
         'to create the new environment. '
         'The default is last stable version (`latest`). '
+        'Use `lts` to use the latest LTS release. '
         'Use `system` to use system-wide node.')
 
     parser.add_option(
@@ -997,6 +998,13 @@ def get_last_stable_node_version():
     return _get_versions_json()[0]['version'].lstrip('v')
 
 
+def get_last_lts_node_version():
+    """
+    Return the last node.js version marked as LTS
+    """
+    return next((v['version'].lstrip('v') for v in _get_versions_json() if v['lts']), None)
+
+
 def get_env_dir(opt, args):
     if opt.python_virtualenv:
         if hasattr(sys, 'real_prefix'):
@@ -1052,8 +1060,10 @@ def main():
     if src_base_url is None:
         src_base_url = 'https://%s/download/release' % src_domain
 
-    if not opt.node or opt.node.lower() == "latest":
+    if not opt.node or opt.node.lower() == 'latest':
         opt.node = get_last_stable_node_version()
+    elif opt.node.lower() == 'lts':
+        opt.node = get_last_lts_node_version()
 
     if opt.list:
         print_node_versions()

--- a/tests/nodeenv_test.py
+++ b/tests/nodeenv_test.py
@@ -130,3 +130,13 @@ def test_mirror_option():
                 nodeenv.main()
                 mock_urlopen.assert_called_with(url)
                 mock_logger.assert_called()
+
+
+@pytest.mark.usefixtures('mock_index_json')
+def test_get_latest_node_version():
+    assert nodeenv.get_last_stable_node_version() == '13.5.0'
+
+
+@pytest.mark.usefixtures('mock_index_json')
+def test_get_lts_node_version():
+    assert nodeenv.get_last_lts_node_version() == '12.14.0'


### PR DESCRIPTION
This PR adds the ability to specify `-n lts` or `--node=lts` to automatically install the latest LTS version on Node. It does this by checking if the `lts` field of the version info, which is either `false` or the string name of the LTS release, is truthy.

Closes #274 