### PR TITLE
Use version specified in `.node-version` if exists

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -106,6 +106,7 @@ class Config(object):
         """
         Load configuration from the given files in reverse order,
         if they exist and have a [nodeenv] section.
+        Additionally, load version from .node-version if file exists.
         """
         for configfile in reversed(configfiles):
             configfile = os.path.expanduser(configfile)
@@ -132,6 +133,10 @@ class Config(object):
                     print('CONFIG {0}: {1} = {2}'.format(
                         os.path.basename(configfile), attr, val))
                 setattr(cls, attr, val)
+
+        if os.path.exists(".node-version"):
+            with open(".node-version", "r") as v_file:
+                setattr(cls, "node", v_file.readlines(1)[0].strip())
 
     @classmethod
     def _dump(cls):


### PR DESCRIPTION
## What

It's pretty common to have a file `.node-version` in a repo to specify the version of node to use.
This will pick up the version specified in this file and use that as the default when `Config` is initialised.

## How to review
### 0. Create an empty directory
### 1. No Arguments, no `.node-version` file
1. Create a node env `nodeenv noargs`
1. Check that the installed version in `noargs` is `latest`
### 2. No Arguments, `.node-version` file
1. Create a `.node-version` file (`echo "14.17.1" > .node-version`)
1. Create a node-env `nodeenv node-version`
1. Check that the installed version in `node-version` is `14.17.1`
### 3. Version specified, `.node-version` file
1. Create a node-env `nodeenv node-version-with-args -n 16.9.0`
1. Check that the installed version in `node-version-with-args` is `16.9.0`