### PR TITLE
Require setuptools on setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     license='BSD',
     author='Eugene Kalinin',
     author_email='e.v.kalinin@gmail.com',
-    install_requires=[],
+    install_requires=['setuptools'],
     description="Node.js virtual environment builder",
     long_description=ldesc,
     py_modules=['nodeenv'],


### PR DESCRIPTION
`nodeenv` imports `pkg_resources`, but it does not require `setuptools` on installation.
This is causing an error on a pre-commit hook.

See https://github.com/pre-commit/pre-commit/issues/2122