### PR TITLE
Update optparse to argparse

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -215,11 +215,9 @@ def create_logger():
 logger = create_logger()
 
 
-def parse_args(check=True):
+def make_parser():
     """
-    Parses command line arguments.
-
-    Set `check` to False to skip validation checks.
+    Make a command line argument parser.
     """
     parser = argparse.ArgumentParser(
         usage="%(prog)s [OPTIONS] DEST_DIR")
@@ -360,6 +358,16 @@ def parse_args(check=True):
     parser.add_argument(
         metavar='DEST_DIR', dest='env_dir', nargs='?', help='Destination directory')
 
+    return parser
+
+
+def parse_args(check=True):
+    """
+    Parses command line arguments.
+
+    Set `check` to False to skip validation checks.
+    """
+    parser = make_parser()
     args = parser.parse_args()
 
     if args.config_file is None:

--- a/nodeenv.py
+++ b/nodeenv.py
@@ -20,7 +20,7 @@ import ssl
 import stat
 import logging
 import operator
-import optparse
+import argparse
 import subprocess
 import tarfile
 import pipes
@@ -169,16 +169,16 @@ def remove_env_bin_from_path(env, env_bin_dir):
     return env.replace(env_bin_dir + ':', '')
 
 
-def node_version_from_opt(opt):
+def node_version_from_args(args):
     """
-    Parse the node version from the optparse options
+    Parse the node version from the argparse args
     """
-    if opt.node == 'system':
+    if args.node == 'system':
         out, err = subprocess.Popen(
             ["node", "--version"], stdout=subprocess.PIPE).communicate()
         return parse_version(clear_output(out).replace('v', ''))
 
-    return parse_version(opt.node)
+    return parse_version(args.node)
 
 
 def create_logger():
@@ -221,11 +221,13 @@ def parse_args(check=True):
 
     Set `check` to False to skip validation checks.
     """
-    parser = optparse.OptionParser(
-        version=nodeenv_version,
-        usage="%prog [OPTIONS] ENV_DIR")
+    parser = argparse.ArgumentParser(
+        usage="%(prog)s [OPTIONS] DEST_DIR")
 
-    parser.add_option(
+    parser.add_argument(
+        '--version', action='version', version=nodeenv_version)
+
+    parser.add_argument(
         '-n', '--node', dest='node', metavar='NODE_VER', default=Config.node,
         help='The node.js version to use, e.g., '
         '--node=0.4.3 will use the node-v0.4.3 '
@@ -234,90 +236,90 @@ def parse_args(check=True):
         'Use `lts` to use the latest LTS release. '
         'Use `system` to use system-wide node.')
 
-    parser.add_option(
+    parser.add_argument(
         '--mirror',
         action="store", dest='mirror',
         help='Set mirror server of nodejs.org to download from.')
 
     if not is_WIN:
-        parser.add_option(
+        parser.add_argument(
             '-j', '--jobs', dest='jobs', default=Config.jobs,
             help='Sets number of parallel commands at node.js compilation. '
             'The default is 2 jobs.')
 
-        parser.add_option(
+        parser.add_argument(
             '--load-average', dest='load_average',
             help='Sets maximum load average for executing parallel commands '
             'at node.js compilation.')
 
-        parser.add_option(
+        parser.add_argument(
             '--without-ssl', dest='without_ssl',
             action='store_true', default=Config.without_ssl,
             help='Build node.js without SSL support')
 
-        parser.add_option(
+        parser.add_argument(
             '--debug', dest='debug',
             action='store_true', default=Config.debug,
             help='Build debug variant of the node.js')
 
-        parser.add_option(
+        parser.add_argument(
             '--profile', dest='profile',
             action='store_true', default=Config.profile,
             help='Enable profiling for node.js')
 
-        parser.add_option(
+        parser.add_argument(
             '--make', '-m', dest='make_path',
             metavar='MAKE_PATH',
             help='Path to make command',
             default=Config.make)
 
-        parser.add_option(
+        parser.add_argument(
             '--source', dest='prebuilt',
             action='store_false', default=Config.prebuilt,
             help='Install node.js from the source')
 
-    parser.add_option(
+    parser.add_argument(
         '-v', '--verbose',
         action='store_true', dest='verbose', default=False,
         help="Verbose mode")
 
-    parser.add_option(
+    parser.add_argument(
         '-q', '--quiet',
         action='store_true', dest='quiet', default=False,
         help="Quiet mode")
 
-    parser.add_option(
+    parser.add_argument(
         '-C', '--config-file', dest='config_file', default=None,
         help="Load a different file than '~/.nodeenvrc'. "
         "Pass an empty string for no config (use built-in defaults).")
 
-    parser.add_option(
+    parser.add_argument(
         '-r', '--requirements',
         dest='requirements', default='', metavar='FILENAME',
         help='Install all the packages listed in the given requirements file.')
 
-    parser.add_option(
+    parser.add_argument(
         '--prompt', dest='prompt',
         help='Provides an alternative prompt prefix for this environment')
 
-    parser.add_option(
+    parser.add_argument(
         '-l', '--list', dest='list',
         action='store_true', default=False,
         help='Lists available node.js versions')
 
-    parser.add_option(
+    parser.add_argument(
         '--update', dest='update',
         action='store_true', default=False,
         help='Install npm packages from file without node')
 
-    parser.add_option(
+    parser.add_argument(
         '--with-npm', dest='with_npm',
         action='store_true', default=Config.with_npm,
         help='Build without installing npm into the new virtual environment. '
         'Required for node.js < 0.6.3. By default, the npm included with '
         'node.js is used. Under Windows, this defaults to true.')
 
-    parser.add_option(
+    parser.add_argument(
         '--npm', dest='npm',
         metavar='NPM_VER', default=Config.npm,
         help='The npm version to use, e.g., '
@@ -325,62 +327,61 @@ def parse_args(check=True):
         'tarball to install. '
         'The default is last available version (`latest`).')
 
-    parser.add_option(
+    parser.add_argument(
         '--no-npm-clean', dest='no_npm_clean',
         action='store_true', default=False,
         help='Skip the npm 0.x cleanup.  Cleanup is enabled by default.')
 
-    parser.add_option(
+    parser.add_argument(
         '--python-virtualenv', '-p', dest='python_virtualenv',
         action='store_true', default=False,
         help='Use current python virtualenv')
 
-    parser.add_option(
+    parser.add_argument(
         '--clean-src', '-c', dest='clean_src',
         action='store_true', default=False,
         help='Remove "src" directory after installation')
 
-    parser.add_option(
+    parser.add_argument(
         '--force', dest='force',
         action='store_true', default=False,
         help='Force installation in a pre-existing directory')
 
-    parser.add_option(
+    parser.add_argument(
         '--prebuilt', dest='prebuilt',
         action='store_true', default=Config.prebuilt,
         help='Install node.js from prebuilt package (default)')
 
-    parser.add_option(
+    parser.add_argument(
         '--ignore_ssl_certs', dest='ignore_ssl_certs',
         action='store_true', default=Config.ignore_ssl_certs,
         help='Ignore certificates for package downloads. - UNSAFE -')
 
-    options, args = parser.parse_args()
+    parser.add_argument(
+        metavar='DEST_DIR', dest='env_dir', nargs='?', help='Destination directory')
 
-    if options.config_file is None:
-        options.config_file = ["./tox.ini", "./setup.cfg", "~/.nodeenvrc"]
-    elif not options.config_file:
-        options.config_file = []
+    args = parser.parse_args()
+
+    if args.config_file is None:
+        args.config_file = ["./tox.ini", "./setup.cfg", "~/.nodeenvrc"]
+    elif not args.config_file:
+        args.config_file = []
     else:
         # Make sure that explicitly provided files exist
-        if not os.path.exists(options.config_file):
+        if not os.path.exists(args.config_file):
             parser.error("Config file '{0}' doesn't exist!".format(
-                options.config_file))
-        options.config_file = [options.config_file]
+                args.config_file))
+        args.config_file = [args.config_file]
 
     if not check:
-        return options, args
+        return args
 
-    if not options.list and not options.python_virtualenv:
-        if not args:
+    if not args.list:
+        if not args.python_virtualenv and not args.env_dir:
             parser.error('You must provide a DEST_DIR or '
                          'use current python virtualenv')
 
-        if len(args) > 1:
-            parser.error('There must be only one argument: DEST_DIR '
-                         '(you gave: {0})'.format(' '.join(args)))
-
-    return options, args
+    return args
 
 
 def mkdir(path):
@@ -566,7 +567,7 @@ def tarfile_open(*args, **kwargs):
         tf.close()
 
 
-def download_node_src(node_url, src_dir, opt):
+def download_node_src(node_url, src_dir, args):
     """
     Download source code
     """
@@ -589,7 +590,7 @@ def download_node_src(node_url, src_dir, opt):
         member_name = operator.attrgetter('name')
 
     with ctx as archive:
-        node_ver = re.escape(opt.node)
+        node_ver = re.escape(args.node)
         rexp_string = r"node-v%s[^/]*/(README\.md|CHANGELOG\.md|LICENSE)"\
             % node_ver
         extract_list = [
@@ -661,11 +662,11 @@ def copy_node_from_prebuilt(env_dir, src_dir, node_version):
     logger.info('.', extra=dict(continued=True))
 
 
-def build_node_from_src(env_dir, src_dir, node_src_dir, opt):
+def build_node_from_src(env_dir, src_dir, node_src_dir, args):
     env = {}
     make_param_names = ['load-average', 'jobs']
     make_param_values = map(
-        lambda x: getattr(opt, x.replace('-', '_')),
+        lambda x: getattr(args, x.replace('-', '_')),
         make_param_names)
     make_opts = [
         '--{0}={1}'.format(name, value)
@@ -680,7 +681,7 @@ def build_node_from_src(env_dir, src_dir, node_src_dir, opt):
         # python 2.* version in this case.
         try:
             _, which_python2_output = callit(
-                ['which', 'python2'], opt.verbose, True, node_src_dir, env
+                ['which', 'python2'], args.verbose, True, node_src_dir, env
             )
             python2_path = which_python2_output[0]
         except (OSError, IndexError):
@@ -701,80 +702,80 @@ def build_node_from_src(env_dir, src_dir, node_src_dir, opt):
         './configure',
         '--prefix=%s' % pipes.quote(env_dir)
     ]
-    if opt.without_ssl:
+    if args.without_ssl:
         conf_cmd.append('--without-ssl')
-    if opt.debug:
+    if args.debug:
         conf_cmd.append('--debug')
-    if opt.profile:
+    if args.profile:
         conf_cmd.append('--profile')
 
-    make_cmd = opt.make_path
+    make_cmd = args.make_path
 
-    callit(conf_cmd, opt.verbose, True, node_src_dir, env)
+    callit(conf_cmd, args.verbose, True, node_src_dir, env)
     logger.info('.', extra=dict(continued=True))
-    callit([make_cmd] + make_opts, opt.verbose, True, node_src_dir, env)
+    callit([make_cmd] + make_opts, args.verbose, True, node_src_dir, env)
     logger.info('.', extra=dict(continued=True))
-    callit([make_cmd + ' install'], opt.verbose, True, node_src_dir, env)
+    callit([make_cmd + ' install'], args.verbose, True, node_src_dir, env)
 
 
-def install_node(env_dir, src_dir, opt):
+def install_node(env_dir, src_dir, args):
     """
     Download source code for node.js, unpack it
     and install it in virtual environment.
     """
     try:
-        install_node_wrapped(env_dir, src_dir, opt)
+        install_node_wrapped(env_dir, src_dir, args)
     except BaseException:
         # this restores the newline suppressed by continued=True
         logger.info('')
         raise
 
 
-def install_node_wrapped(env_dir, src_dir, opt):
+def install_node_wrapped(env_dir, src_dir, args):
     env_dir = abspath(env_dir)
-    node_src_dir = join(src_dir, to_utf8('node-v%s' % opt.node))
-    src_type = "prebuilt" if opt.prebuilt else "source"
+    node_src_dir = join(src_dir, to_utf8('node-v%s' % args.node))
+    src_type = "prebuilt" if args.prebuilt else "source"
 
-    logger.info(' * Install %s node (%s) ' % (src_type, opt.node),
+    logger.info(' * Install %s node (%s) ' % (src_type, args.node),
                 extra=dict(continued=True))
 
-    if opt.prebuilt:
-        node_url = get_node_bin_url(opt.node)
+    if args.prebuilt:
+        node_url = get_node_bin_url(args.node)
     else:
-        node_url = get_node_src_url(opt.node)
+        node_url = get_node_src_url(args.node)
 
     # get src if not downloaded yet
     if not os.path.exists(node_src_dir):
-        download_node_src(node_url, src_dir, opt)
+        download_node_src(node_url, src_dir, args)
 
     logger.info('.', extra=dict(continued=True))
 
-    if opt.prebuilt:
-        copy_node_from_prebuilt(env_dir, src_dir, opt.node)
+    if args.prebuilt:
+        copy_node_from_prebuilt(env_dir, src_dir, args.node)
     else:
-        build_node_from_src(env_dir, src_dir, node_src_dir, opt)
+        build_node_from_src(env_dir, src_dir, node_src_dir, args)
 
     logger.info(' done.')
 
 
-def install_npm(env_dir, _src_dir, opt):
+def install_npm(env_dir, _src_dir, args):
     """
     Download source code for npm, unpack it
     and install it in virtual environment.
     """
-    logger.info(' * Install npm.js (%s) ... ' % opt.npm,
+    logger.info(' * Install npm.js (%s) ... ' % args.npm,
                 extra=dict(continued=True))
     env = dict(
         os.environ,
-        clean='no' if opt.no_npm_clean else 'yes',
-        npm_install=opt.npm,
+        clean='no' if args.no_npm_clean else 'yes',
+        npm_install=args.npm,
     )
     proc = subprocess.Popen(
         (
             'bash', '-c',
             '. {0} && npm install -g npm@{1}'.format(
                 pipes.quote(join(env_dir, 'bin', 'activate')),
-                opt.npm,
+                args.npm,
             )
         ),
         env=env,
@@ -783,19 +784,19 @@ def install_npm(env_dir, _src_dir, opt):
         stderr=subprocess.STDOUT,
     )
     out, _ = proc.communicate()
-    if opt.verbose:
+    if args.verbose:
         logger.info(out)
     logger.info('done.')
 
 
-def install_npm_win(env_dir, src_dir, opt):
+def install_npm_win(env_dir, src_dir, args):
     """
     Download source code for npm, unpack it
     and install it in virtual environment.
     """
-    logger.info(' * Install npm.js (%s) ... ' % opt.npm,
+    logger.info(' * Install npm.js (%s) ... ' % args.npm,
                 extra=dict(continued=True))
-    npm_url = 'https://github.com/npm/cli/archive/v%s.zip' % opt.npm
+    npm_url = 'https://github.com/npm/cli/archive/v%s.zip' % args.npm
     npm_contents = io.BytesIO(urlopen(npm_url).read())
 
     bin_path = join(env_dir, 'Scripts')
@@ -813,7 +814,7 @@ def install_npm_win(env_dir, src_dir, opt):
     with zipfile.ZipFile(npm_contents, 'r') as zipf:
         zipf.extractall(src_dir)
 
-    npm_ver = 'cli-%s' % opt.npm
+    npm_ver = 'cli-%s' % args.npm
     shutil.copytree(join(src_dir, npm_ver), node_modules_path)
     shutil.copy(join(src_dir, npm_ver, 'bin', 'npm.cmd'),
                 join(bin_path, 'npm.cmd'))
@@ -826,21 +827,21 @@ def install_npm_win(env_dir, src_dir, opt):
         shutil.copytree(join(bin_path, 'node_modules'),
                         join(env_dir, 'bin', 'node_modules'))
         npm_gh_url = 'https://raw.githubusercontent.com/npm/cli'
-        npm_bin_url = '{}/{}/bin/npm'.format(npm_gh_url, opt.npm)
+        npm_bin_url = '{}/{}/bin/npm'.format(npm_gh_url, args.npm)
         writefile(join(env_dir, 'bin', 'npm'), urlopen(npm_bin_url).read())
 
 
-def install_packages(env_dir, opt):
+def install_packages(env_dir, args):
     """
     Install node.js packages via npm
     """
     logger.info(' * Install node.js packages ... ',
                 extra=dict(continued=True))
     packages = [package.strip() for package in
-                open(opt.requirements).readlines()]
+                open(args.requirements).readlines()]
     activate_path = join(env_dir, 'bin', 'activate')
-    real_npm_ver = opt.npm if opt.npm.count(".") == 2 else opt.npm + ".0"
-    if opt.npm == "latest" or real_npm_ver >= "1.0.0":
+    real_npm_ver = args.npm if args.npm.count(".") == 2 else args.npm + ".0"
+    if args.npm == "latest" or real_npm_ver >= "1.0.0":
         cmd = '. ' + pipes.quote(activate_path) + \
               ' && npm install -g %(pack)s'
     else:
@@ -852,12 +853,12 @@ def install_packages(env_dir, opt):
         if not package:
             continue
         callit(cmd=[
-            cmd % {"pack": package}], show_stdout=opt.verbose, in_shell=True)
+            cmd % {"pack": package}], show_stdout=args.verbose, in_shell=True)
 
     logger.info('done.')
 
 
-def install_activate(env_dir, opt):
+def install_activate(env_dir, args):
     """
     Install virtual environment activation script
     """
@@ -882,13 +883,13 @@ def install_activate(env_dir, opt):
     if is_CYGWIN:
         mkdir(bin_dir)
 
-    if opt.node == "system":
+    if args.node == "system":
         files["node"] = SHIM
 
     mod_dir = join('lib', 'node_modules')
-    prompt = opt.prompt or '(%s)' % os.path.basename(os.path.abspath(env_dir))
+    prompt = args.prompt or '(%s)' % os.path.basename(os.path.abspath(env_dir))
 
-    if opt.node == "system":
+    if args.node == "system":
         env = os.environ.copy()
         env.update({'PATH': remove_env_bin_from_path(env['PATH'], bin_dir)})
         for candidate in ("nodejs", "node"):
@@ -923,7 +924,7 @@ def install_activate(env_dir, opt):
         # `bin/activate` should be appended if we inside
         # existing python's virtual environment
         need_append = False
-        if opt.python_virtualenv:
+        if args.python_virtualenv:
             disable_prompt = DISABLE_PROMPT.get(name, '')
             enable_prompt = ENABLE_PROMPT.get(name, '')
             content = disable_prompt + content + enable_prompt
@@ -946,19 +947,19 @@ def set_predeactivate_hook(env_dir):
             hook.write(PREDEACTIVATE_SH)
 
 
-def create_environment(env_dir, opt):
+def create_environment(env_dir, args):
     """
     Creates a new environment in ``env_dir``.
     """
-    if os.path.exists(env_dir) and not opt.python_virtualenv:
+    if os.path.exists(env_dir) and not args.python_virtualenv:
         logger.info(' * Environment already exists: %s', env_dir)
-        if not opt.force:
+        if not args.force:
             sys.exit(2)
     src_dir = to_utf8(abspath(join(env_dir, 'src')))
     mkdir(src_dir)
 
-    if opt.node != "system":
-        install_node(env_dir, src_dir, opt)
+    if args.node != "system":
+        install_node(env_dir, src_dir, args)
     else:
         mkdir(join(env_dir, 'bin'))
         mkdir(join(env_dir, 'lib'))
@@ -966,16 +967,16 @@ def create_environment(env_dir, opt):
     # activate script install must be
     # before npm install, npm use activate
     # for install
-    install_activate(env_dir, opt)
-    if node_version_from_opt(opt) < parse_version("0.6.3") or opt.with_npm:
+    install_activate(env_dir, args)
+    if node_version_from_args(args) < parse_version("0.6.3") or args.with_npm:
         instfunc = install_npm_win if is_WIN or is_CYGWIN else install_npm
-        instfunc(env_dir, src_dir, opt)
-    if opt.requirements:
-        install_packages(env_dir, opt)
-    if opt.python_virtualenv:
+        instfunc(env_dir, src_dir, args)
+    if args.requirements:
+        install_packages(env_dir, args)
+    if args.python_virtualenv:
         set_predeactivate_hook(env_dir)
     # Cleanup
-    if opt.clean_src:
+    if args.clean_src:
         shutil.rmtree(src_dir)
 
 
@@ -1015,8 +1016,8 @@ def get_last_lts_node_version():
                  for v in _get_versions_json() if v['lts']), None)
 
 
-def get_env_dir(opt, args):
-    if opt.python_virtualenv:
+def get_env_dir(args):
+    if args.python_virtualenv:
         if hasattr(sys, 'real_prefix'):
             res = sys.prefix
         elif hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix:
@@ -1027,7 +1028,7 @@ def get_env_dir(opt, args):
             logger.error('No python virtualenv is available')
             sys.exit(2)
     else:
-        res = args[0]
+        res = args.env_dir
     return to_utf8(res)
 
 
@@ -1041,27 +1042,27 @@ def main():
         Config._dump()
         return
 
-    opt, args = parse_args(check=False)
+    args = parse_args(check=False)
     # noinspection PyProtectedMember
-    Config._load(opt.config_file, opt.verbose)
+    Config._load(args.config_file, args.verbose)
 
-    opt, args = parse_args()
+    args = parse_args()
 
-    if opt.node.lower() == 'system' and is_WIN:
+    if args.node.lower() == 'system' and is_WIN:
         logger.error('Installing system node.js on win32 is not supported!')
         exit(1)
 
     global src_base_url
     global ignore_ssl_certs
 
-    ignore_ssl_certs = opt.ignore_ssl_certs
+    ignore_ssl_certs = args.ignore_ssl_certs
 
     src_domain = None
-    if opt.mirror:
-        if '://' in opt.mirror:
-            src_base_url = opt.mirror
+    if args.mirror:
+        if '://' in args.mirror:
+            src_base_url = args.mirror
         else:
-            src_domain = opt.mirror
+            src_domain = args.mirror
     # use unofficial builds only if musl and no explicitly chosen mirror
     elif is_x86_64_musl():
         src_domain = 'unofficial-builds.nodejs.org'
@@ -1070,19 +1071,19 @@ def main():
     if src_base_url is None:
         src_base_url = 'https://%s/download/release' % src_domain
 
-    if not opt.node or opt.node.lower() == 'latest':
-        opt.node = get_last_stable_node_version()
-    elif opt.node.lower() == 'lts':
-        opt.node = get_last_lts_node_version()
+    if not args.node or args.node.lower() == 'latest':
+        args.node = get_last_stable_node_version()
+    elif args.node.lower() == 'lts':
+        args.node = get_last_lts_node_version()
 
-    if opt.list:
+    if args.list:
         print_node_versions()
-    elif opt.update:
-        env_dir = get_env_dir(opt, args)
-        install_packages(env_dir, opt)
+    elif args.update:
+        env_dir = get_env_dir(args)
+        install_packages(env_dir, args)
     else:
-        env_dir = get_env_dir(opt, args)
-        create_environment(env_dir, opt)
+        env_dir = get_env_dir(args)
+        create_environment(env_dir, args)
 
 
 # ---------------------------------------------------------


### PR DESCRIPTION
`optparse` is deprecated since Python 3.2: <https://docs.python.org/3/library/optparse.html>

This PR updates the `optparse` code to use `argparse`, as well as to use the variable naming conventions that are typically used with `argparse` code. See: <https://docs.python.org/3/library/argparse.html#upgrading-optparse-code>

Also: you had one function called `parse_args` which (1) built a parser, and (2) invoked the parser to actually read the command line args, and then execute some follow-up logic. I broke this into two functions.

## Some context

I have a [simple script](https://github.com/andrey-mishchenko/fish-python-argparse-completions) for automatically-generating fish completions for commands implemented in Python. I was using it to generate `nodeenv` completions for fish (submitted in [this PR](https://github.com/fish-shell/fish-shell/pull/8533)). Since most Python commands use `argparse`, and `optparse` is deprecated, I went ahead and bumped nodeenv to `argparse`.

## Notes

For long arguments `--like-this=some_value`, using the equals sign is optional: <https://stackoverflow.com/questions/14567289/equals-sign-in-pythons-argument>

I understand if you don't want to merge this upstream for whatever reason (inconvenience, not worth it for you, etc.), but I figured I'd submit in case you like the bump to `argparse`.