### PR TITLE
python -> python3

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """


### PR DESCRIPTION
MacOS 12.3 removed `python` in favour of `python3`

Closes: #301 