### PR TITLE
Add ability to configure mirror through setting file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -242,15 +242,17 @@ the keys in that file are the long command-line option names.
 These are the available options and their defaults::
 
     [nodeenv]
-    debug = False
-    jobs = 2
-    make = make
-    node = latest
-    npm = latest
-    prebuilt = False
-    profile = False
+    node = 'latest'
+    npm = 'latest'
     with_npm = False
+    jobs = '2'
     without_ssl = False
+    debug = False
+    profile = False
+    make = 'make'
+    prebuilt = True
+    ignore_ssl_certs = False
+    mirror = None
 
 Alternatives
 ------------

--- a/nodeenv.py
+++ b/nodeenv.py
@@ -100,6 +100,7 @@ class Config(object):
     make = 'make'
     prebuilt = True
     ignore_ssl_certs = False
+    mirror = None
 
     @classmethod
     def _load(cls, configfiles, verbose=False):
@@ -236,7 +237,7 @@ def make_parser():
 
     parser.add_argument(
         '--mirror',
-        action="store", dest='mirror',
+        action="store", dest='mirror', default=Config.mirror,
         help='Set mirror server of nodejs.org to download from.')
 
     if not is_WIN:


### PR DESCRIPTION
There is a need for the ability to configure `mirror` through the configuration file (not just command line) when this package is used by another build tool.