### PR TITLE
Add --with-npm to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -130,7 +130,7 @@ Get available node.js versions::
 Install node.js "0.4.3" without ssl support with 4 parallel commands 
 for compilation and npm.js "0.3.17"::
 
-    $ nodeenv --without-ssl --node=0.4.3 --npm=0.3.17 --jobs=4 env-4.3
+    $ nodeenv --without-ssl --node=0.4.3 --npm=0.3.17 --with-npm --jobs=4 env-4.3
 
 Install node.js from the source::
 


### PR DESCRIPTION
This `python -m nodeenv env --node=18.1.0 --npm=7.15.1` doesn't install npm@7.15.1
It will only work if we add `--with-npm`, so update docs example.
I think caused by this https://github.com/ekalinin/nodeenv/commit/a92badca32381b97a8743e7097d6ff90208dfd48