### PR TITLE
Fix function name in fish_prompt

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -1492,7 +1492,7 @@ if test -z "$NODE_VIRTUAL_ENV_DISABLE_PROMPT"
 
         # Restore the original $status
         echo "exit $old_status" | source
-        _old_fish_prompt
+        _node_old_fish_prompt
     end
 
     set -gx _OLD_NODE_FISH_PROMPT_OVERRIDE "$NODE_VIRTUAL_ENV"


### PR DESCRIPTION
One of the references to the old function name `_old_fish_prompt` was left behind, and this completely breaks the prompt in fish.

It looks like this:
```sh
eashwar@laptop ~/s/homepage (master)> . nodeenv/bin/activate.fish
fish: Unknown command: _old_fish_prompt
nodevenv/bin/activate.fish (line 131): 
        _old_fish_prompt
        ^
in function 'fish_prompt'
in command substitution
```

It would be nice if a patch release could be made after merging this fix, because manually fixing each nodeenv after creation is quite annoying.