### PR TITLE
Add support for riscv64

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -547,6 +547,7 @@ def get_node_bin_url(version):
         'armv8.4': 'arm64',
         'ppc64le': 'ppc64le',   # Power PC
         's390x': 's390x',       # IBM S390x
+        'riscv64': 'riscv64',   # RISCV 64
     }
     sysinfo = {
         'system': platform.system().lower(),

--- a/nodeenv.py
+++ b/nodeenv.py
@@ -529,6 +529,8 @@ def get_root_url(version):
 def is_x86_64_musl():
     return sysconfig.get_config_var('HOST_GNU_TYPE') == 'x86_64-pc-linux-musl'
 
+def is_riscv64():
+    return platform.machine() == "riscv64"
 
 def get_node_bin_url(version):
     archmap = {
@@ -1083,7 +1085,7 @@ def main():
         else:
             src_domain = args.mirror
     # use unofficial builds only if musl and no explicitly chosen mirror
-    elif is_x86_64_musl():
+    elif is_x86_64_musl() or is_riscv64():
         src_domain = 'unofficial-builds.nodejs.org'
     else:
         src_domain = 'nodejs.org'

--- a/nodeenv.py
+++ b/nodeenv.py
@@ -529,8 +529,10 @@ def get_root_url(version):
 def is_x86_64_musl():
     return sysconfig.get_config_var('HOST_GNU_TYPE') == 'x86_64-pc-linux-musl'
 
+
 def is_riscv64():
-    return platform.machine() == "riscv64"
+    return platform.machine() == 'riscv64'
+
 
 def get_node_bin_url(version):
     archmap = {

--- a/tests/nodeenv_test.py
+++ b/tests/nodeenv_test.py
@@ -6,6 +6,7 @@ import pipes
 import subprocess
 import sys
 import sysconfig
+import platform
 
 import mock
 import pytest
@@ -111,6 +112,8 @@ def test_mirror_option():
     musl_type = ['x86_64-pc-linux-musl', 'x86_64-unknown-linux-musl']
     # Check if running on musl system and delete last mirror if it is
     if sys_type in musl_type:
+        urls.pop()
+    elif platform.machine() == "riscv64":
         urls.pop()
     with open(os.path.join(HERE, 'nodejs_index.json'), 'rb') as f:
         def rewind(_):


### PR DESCRIPTION
This PR adds the ability for nodeenv to detect RISC-V 64 architecture and download pre-built nodejs from unofficial upstream. Tested in Arch Linux RISC-V 64.

* How to verified

Follow the [instruction](https://github.com/felixonmars/archriscv-packages/wiki/Setup-Arch-Linux-RISC-V-Development-Environment) to setup Arch Linux RISC-V QEMU environment. Then just run the `python setup.py test`.