### PR TITLE
No runtime dependency on setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     license='BSD',
     author='Eugene Kalinin',
     author_email='e.v.kalinin@gmail.com',
-    install_requires=['setuptools'],
+    install_requires=[],
     python_requires=(
         ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
     ),


### PR DESCRIPTION
You don’t import setuptools, so it doesn’t belong into `install_requires`

If you want to specify it as build time dependency, do it like this: https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/#build-time-dependencies