### PR TITLE
Add Windows + Docker build to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,9 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+        cache-dependency-path: |
+          requirements-dev.txt
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,11 +85,14 @@ jobs:
         - uses: actions/checkout@v2
         - name: Windows Install
           run: pip install .
-        - name: Install + Run NodeJS
+        - name: List Versions
+          run: nodeenv --list
+        - name: Install Node
           run: |
-            nodeenv --list
-            nodeenv ./node
-            ./node/bin/node --version
+            nodeenv node
+            ls node
+        - name: Check NodeJS Executable
+          run: node\Scripts\node --version
 
   docker-linux:
     name: Docker Linux (${{ matrix.python-version }} ${{ matrix.docker-platform }} ${{ matrix.python-os-distro }})

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,11 +78,23 @@ jobs:
           name: html-report
           path: htmlcov
 
-  test-windows:
-      name: Windows Test (Python 3:10)
+  test-windows-install:
+      name: Windows Install Python ${{ matrix.python-version }}
       runs-on: windows-latest
+      strategy:
+        fail-fast: false
+        matrix:
+          python-version:
+          - 2.7
+          - 3.7
+          - 3.8
+          - 3.9
+          - '3.10'
       steps:
         - uses: actions/checkout@v2
+        - uses: actions/setup-python@v2
+          with:
+            python-version: ${{ matrix.python-version }}
         - name: Windows Install
           run: pip install .
         - name: List Versions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,5 +143,5 @@ jobs:
         - uses: actions/checkout@v2
         - name: Docker Build
           run: |
-            docker build -f tests/Dockerfile --build-arg OS_DISTRO=windowsservercore .
+            docker build -f tests/Dockerfile.windows .
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,3 +74,56 @@ jobs:
         with:
           name: html-report
           path: htmlcov
+
+  test-windows:
+      name: Windows Test (Python 3:10)
+      runs-on: windows-latest
+      steps:
+        - uses: actions/checkout@v2
+        - name: Windows Install
+          run: pip install .
+        - name: Install + Run NodeJS
+          run: |
+            nodeenv --list
+            nodeenv ./node
+            ./node/bin/node --version
+
+  docker-linux:
+    name: Docker Linux (${{ matrix.python-version }} ${{ matrix.docker-platform }} ${{ matrix.python-os-distro }})
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        docker-platform: [linux/amd64, linux/arm64]
+        python-os-distro: [slim-bullseye, slim-buster]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          install: true
+      - name: Docker Build
+        uses: docker/build-push-action@v3
+        # https://github.com/docker/build-push-action/#inputs
+        with:
+          context: .
+          file: tests/Dockerfile
+          platforms: "${{ matrix.docker-platform }}"
+          build-args: |
+            PYTHON_VERSION=${{ matrix.python-version }}
+            OS_DISTRO=${{ matrix.python-os-distro }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  docker-windows:
+      name: Docker Windows
+      runs-on: windows-latest
+      steps:
+        - uses: actions/checkout@v2
+        - name: Docker Build
+          run: |
+            docker build -f tests/Dockerfile --build-arg OS_DISTRO=windowsservercore .
+

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,18 @@
+ARG PYTHON_VERSION=3.10
+ARG OS_DISTRO=bullseye
+
+FROM python:${PYTHON_VERSION}-${OS_DISTRO}
+
+WORKDIR /app
+
+COPY . .
+
+RUN pip install .
+
+RUN nodeenv --list
+
+RUN nodeenv /node
+
+RUN /node/bin/node --version
+
+CMD [ "/node/bin/node" ]

--- a/tests/Dockerfile.windows
+++ b/tests/Dockerfile.windows
@@ -1,5 +1,5 @@
 ARG PYTHON_VERSION=3.10
-ARG OS_DISTRO=bullseye
+ARG OS_DISTRO=windowsservercore
 
 FROM python:${PYTHON_VERSION}-${OS_DISTRO}
 
@@ -8,6 +8,8 @@ ARG OS_DISTRO
 
 ENV PYTHON_VERSION=${PYTHON_VERSION}
 ENV OS_DISTRO=${OS_DISTRO}
+
+RUN certutil -generateSSTFromWU roots.sst; certutil -addstore -f root roots.sst; del roots.sst
 
 WORKDIR /app
 
@@ -19,4 +21,4 @@ RUN nodeenv --list
 
 RUN nodeenv node
 
-RUN node/bin/node --version
+RUN node\Scripts\node --version


### PR DESCRIPTION
Reproduction for #316 

* Add caching of the pip install of developer dependencies to speed up CI
* Add a windows build to CI (in docker and outside)
* Add a linux matrix (without alpine)