### PR TITLE
Make the mock dependency optional

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,6 @@
 
 coverage
 flake8
-mock
+mock; python_version < '3.3'
 pytest
 tox

--- a/tests/nodeenv_test.py
+++ b/tests/nodeenv_test.py
@@ -7,7 +7,10 @@ import subprocess
 import sys
 import sysconfig
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 import nodeenv

--- a/tests/test_install_activate.py
+++ b/tests/test_install_activate.py
@@ -1,7 +1,10 @@
 import sys
 import os
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import pytest
 
 import nodeenv


### PR DESCRIPTION
Since Python 3.3 unittest contains the mock module, deprecating the seperate mock module.