### PR TITLE
fix: prevent error about fish_prompt when using nested fish instances

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -1397,10 +1397,13 @@ function deactivate_node -d 'Exit nodeenv and return to normal environment.'
         # `fish_prompt` using `functions -e`.
         set -l fish_function_path
 
-        # Erase virtualenv's `fish_prompt` and restore the original.
-        functions -e fish_prompt
-        functions -c _node_old_fish_prompt fish_prompt
-        functions -e _node_old_fish_prompt
+        # Prevents error when using nested fish instances
+        if functions -q _node_old_fish_prompt
+            # Erase virtualenv's `fish_prompt` and restore the original.
+            functions -e fish_prompt
+            functions -c _node_old_fish_prompt fish_prompt
+            functions -e _node_old_fish_prompt
+        end
         set -e _OLD_NODE_FISH_PROMPT_OVERRIDE
     end
 


### PR DESCRIPTION
This PR mirrors https://github.com/python/cpython/pull/93931, which addresses a pretty much identical issue for venv https://github.com/python/cpython/issues/93858.

Specifically for my case, the same `functions: Function “_old_fish_prompt” does not exist` error will be thrown when launching `tmux` (which subsequently launches `fish`) within `fish`.