### PR TITLE
node: use `.xz` archives as `.gz` returns 404

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -557,7 +557,7 @@ def get_node_bin_url(version):
     elif is_x86_64_musl():
         postfix = '-linux-x64-musl.tar.gz'
     else:
-        postfix = '-%(system)s-%(arch)s.tar.gz' % sysinfo
+        postfix = '-%(system)s-%(arch)s.tar.xz' % sysinfo
     filename = 'node-v%s%s' % (version, postfix)
     return get_root_url(version) + filename
 


### PR DESCRIPTION
Installation on Linux fails with the following error:

```
 * Install prebuilt node (19.8.1) ...
Traceback (most recent call last):
  File "/app/.venv/bin/nodeenv", line 8, in <module>
    sys.exit(main())
  File "/app/.venv/lib/python3.10/site-packages/nodeenv.py", line 1104, in main
    create_environment(env_dir, args)
  File "/app/.venv/lib/python3.10/site-packages/nodeenv.py", line 980, in create_environment
    install_node(env_dir, src_dir, args)
  File "/app/.venv/lib/python3.10/site-packages/nodeenv.py", line 739, in install_node
    install_node_wrapped(env_dir, src_dir, args)
  File "/app/.venv/lib/python3.10/site-packages/nodeenv.py", line 772, in install_node_wrapped
    copy_node_from_prebuilt(env_dir, src_dir, args.node)
  File "/app/.venv/lib/python3.10/site-packages/nodeenv.py", line 665, in copy_node_from_prebuilt
    src_folder, = glob.glob(src_folder_tpl)
ValueError: not enough values to unpack (expected 1, got 0)
```

`tar.gz` links like https://nodejs.org/download/release/v19.8.1/node-v19.8.1-linux-x64.tar.gz lead to a 404 page
I don't know if this is just a long outage or what on the nodejs side, but the home page also offers the `xz` file for download for Linux users
Tried a few random versions, all have this issue.
![image](https://user-images.githubusercontent.com/1771332/225726015-6c1ff63f-882c-45ad-93ee-1c9d0a56ec6a.png)
