### PR TITLE
Switch to packaging

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,8 +31,10 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --upgrade tox
+        # build and test dependencies
+        python -m pip install --upgrade pip wheel tox
+        # runtime dependencies
+        python -m pip install -e .
 
     - name: Run tox targets for ${{ matrix.python-version }}
       run: |

--- a/nodeenv.py
+++ b/nodeenv.py
@@ -519,9 +519,9 @@ def callit(cmd, show_stdout=True, in_shell=False,
     return proc.returncode, all_output
 
 
-def get_root_url(version):
-    if version.parse(version) > version.parse("0.5.0"):
-        return '%s/v%s/' % (src_base_url, version)
+def get_root_url(version_str):
+    if version.parse(version_str) > version.parse("0.5.0"):
+        return '%s/v%s/' % (src_base_url, version_str)
     else:
         return src_base_url
 

--- a/nodeenv.py
+++ b/nodeenv.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover (py3 only)
     import http
     IncompleteRead = http.client.IncompleteRead
 
-from pkg_resources import parse_version
+from packaging import version
 
 nodeenv_version = '1.8.0'
 
@@ -177,9 +177,9 @@ def node_version_from_args(args):
     if args.node == 'system':
         out, err = subprocess.Popen(
             ["node", "--version"], stdout=subprocess.PIPE).communicate()
-        return parse_version(clear_output(out).replace('v', ''))
+        return version.parse(clear_output(out).replace('v', ''))
 
-    return parse_version(args.node)
+    return version.parse(args.node)
 
 
 def create_logger():
@@ -520,7 +520,7 @@ def callit(cmd, show_stdout=True, in_shell=False,
 
 
 def get_root_url(version):
-    if parse_version(version) > parse_version("0.5.0"):
+    if version.parse(version) > version.parse("0.5.0"):
         return '%s/v%s/' % (src_base_url, version)
     else:
         return src_base_url
@@ -1004,7 +1004,7 @@ def create_environment(env_dir, args):
     # before npm install, npm use activate
     # for install
     install_activate(env_dir, args)
-    if node_version_from_args(args) < parse_version("0.6.3") or args.with_npm:
+    if node_version_from_args(args) < version.parse("0.6.3") or args.with_npm:
         instfunc = install_npm_win if is_WIN or is_CYGWIN else install_npm
         instfunc(env_dir, src_dir, args)
     if args.requirements:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     license='BSD',
     author='Eugene Kalinin',
     author_email='e.v.kalinin@gmail.com',
-    install_requires=['setuptools'],
+    install_requires=['packaging'],
     python_requires=(
         ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
     ),

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,13 @@ Node.js Virtual Environment builder.
 """
 import codecs
 import os
+import sys
+
+from setuptools import setup
+
+sys.path.insert(0, '.')
 
 from nodeenv import nodeenv_version
-from setuptools import setup
 
 
 def read_file(file_name):


### PR DESCRIPTION
This PR

- switches from the deprecated `pkg_resources` to `packaging` (Fixes #337)
- changes CI so it actually installs runtime dependencies specified in the package metadata’s `install_requires` (instead of manually specifying `setuptools`)
- adds a `pyproject.toml` for a standards based build (instead of legacy convention based)