### PR TITLE
Fix `ValueError: not enough values to unpack` in nodeenv.py

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -678,7 +678,7 @@ def copy_node_from_prebuilt(env_dir, src_dir, node_version):
         dest = env_dir
 
     src_folder_tpl = src_dir + to_utf8('/node-v%s*' % node_version)
-    src_folder, = glob.glob(src_folder_tpl)
+    src_folder, _ = glob.glob(src_folder_tpl)
     copytree(src_folder, dest, True)
 
     if is_CYGWIN:


### PR DESCRIPTION
You need a place holder to extract the result like that.


```
>>> src_folder, =  glob.glob('/tmp/node-v18.16.1')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: not enough values to unpack (expected 1, got 0)
```