### PR TITLE
On Python 3.3+, replace pipes.quote with shlex.quote

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -23,7 +23,10 @@ import operator
 import argparse
 import subprocess
 import tarfile
-import pipes
+try:
+    from shlex import quote as _quote  # Python 3.3+
+except ImportError:
+    from pipes import quote as _quote  # Python 2.7
 import platform
 import zipfile
 import shutil
@@ -728,7 +731,7 @@ def build_node_from_src(env_dir, src_dir, node_src_dir, args):
 
     conf_cmd = [
         './configure',
-        '--prefix=%s' % pipes.quote(env_dir)
+        '--prefix=%s' % _quote(env_dir)
     ]
     if args.without_ssl:
         conf_cmd.append('--without-ssl')
@@ -810,7 +813,7 @@ def install_npm(env_dir, _src_dir, args):
         (
             'bash', '-c',
             '. {0} && npm install -g npm@{1}'.format(
-                pipes.quote(join(env_dir, 'bin', 'activate')),
+                _quote(join(env_dir, 'bin', 'activate')),
                 args.npm,
             )
         ),
@@ -878,10 +881,10 @@ def install_packages(env_dir, args):
     activate_path = join(env_dir, 'bin', 'activate')
     real_npm_ver = args.npm if args.npm.count(".") == 2 else args.npm + ".0"
     if args.npm == "latest" or real_npm_ver >= "1.0.0":
-        cmd = '. ' + pipes.quote(activate_path) + \
+        cmd = '. ' + _quote(activate_path) + \
               ' && npm install -g %(pack)s'
     else:
-        cmd = '. ' + pipes.quote(activate_path) + \
+        cmd = '. ' + _quote(activate_path) + \
               ' && npm install %(pack)s' + \
               ' && npm activate %(pack)s'
 

--- a/nodeenv.py
+++ b/nodeenv.py
@@ -23,10 +23,10 @@ import operator
 import argparse
 import subprocess
 import tarfile
-try:
-    from shlex import quote as _quote  # Python 3.3+
-except ImportError:
-    from pipes import quote as _quote  # Python 2.7
+if sys.version_info < (3, 3):
+    from pipes import quote as _quote
+else:
+    from shlex import quote as _quote
 import platform
 import zipfile
 import shutil

--- a/tests/nodeenv_test.py
+++ b/tests/nodeenv_test.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import os.path
-import pipes
+try:
+    from shlex import quote as _quote  # Python 3.3+
+except ImportError:
+    from pipes import quote as _quote  # Python 2.7
 import subprocess
 import sys
 import sysconfig
@@ -29,7 +32,7 @@ def test_smoke(tmpdir):
         '-m', 'nodeenv', '--prebuilt', nenv_path,
     ])
     assert os.path.exists(nenv_path)
-    activate = pipes.quote(os.path.join(nenv_path, 'bin', 'activate'))
+    activate = _quote(os.path.join(nenv_path, 'bin', 'activate'))
     subprocess.check_call([
         'sh', '-c', '. {} && node --version'.format(activate),
     ])
@@ -44,7 +47,7 @@ def test_smoke_n_system_special_chars(tmpdir):
         '-m', 'nodeenv', '-n', 'system', nenv_path,
     ))
     assert os.path.exists(nenv_path)
-    activate = pipes.quote(os.path.join(nenv_path, 'bin', 'activate'))
+    activate = _quote(os.path.join(nenv_path, 'bin', 'activate'))
     subprocess.check_call([
         'sh', '-c', '. {} && node --version'.format(activate),
     ])

--- a/tests/nodeenv_test.py
+++ b/tests/nodeenv_test.py
@@ -2,10 +2,10 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import os.path
-try:
-    from shlex import quote as _quote  # Python 3.3+
-except ImportError:
-    from pipes import quote as _quote  # Python 2.7
+if sys.version_info < (3, 3):
+    from pipes import quote as _quote
+else:
+    from shlex import quote as _quote
 import subprocess
 import sys
 import sysconfig


### PR DESCRIPTION
The `pipes.quote()` function was undocumented, and the pipes module was deprecated in Python 3.11 and will be removed in Python 3.13.

Fixes #341.

This is a one-to-one replacement of `pipes.quote` with [`shlex.quote`](https://docs.python.org/3/library/shlex.html#shlex.quote); I did not attempt to audit the shell escaping for correctness and safety.