### PR TITLE
BUG: fix deprecation warning in Python 3.12 (pipes is deprecated)

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -18,12 +18,12 @@ import os
 import re
 import ssl
 import stat
+import sys
 import logging
 import operator
 import argparse
 import subprocess
 import tarfile
-import pipes
 import platform
 import zipfile
 import shutil
@@ -46,6 +46,11 @@ except ImportError:  # pragma: no cover (py3 only)
     IncompleteRead = http.client.IncompleteRead
 
 from packaging import version
+
+if sys.version_info >= (3, 3):
+    from shlex import quote
+else:
+    from pipes import quote
 
 nodeenv_version = '1.8.0'
 
@@ -728,7 +733,7 @@ def build_node_from_src(env_dir, src_dir, node_src_dir, args):
 
     conf_cmd = [
         './configure',
-        '--prefix=%s' % pipes.quote(env_dir)
+        '--prefix=%s' % quote(env_dir)
     ]
     if args.without_ssl:
         conf_cmd.append('--without-ssl')
@@ -810,7 +815,7 @@ def install_npm(env_dir, _src_dir, args):
         (
             'bash', '-c',
             '. {0} && npm install -g npm@{1}'.format(
-                pipes.quote(join(env_dir, 'bin', 'activate')),
+                quote(join(env_dir, 'bin', 'activate')),
                 args.npm,
             )
         ),
@@ -878,10 +883,10 @@ def install_packages(env_dir, args):
     activate_path = join(env_dir, 'bin', 'activate')
     real_npm_ver = args.npm if args.npm.count(".") == 2 else args.npm + ".0"
     if args.npm == "latest" or real_npm_ver >= "1.0.0":
-        cmd = '. ' + pipes.quote(activate_path) + \
+        cmd = '. ' + quote(activate_path) + \
               ' && npm install -g %(pack)s'
     else:
-        cmd = '. ' + pipes.quote(activate_path) + \
+        cmd = '. ' + quote(activate_path) + \
               ' && npm install %(pack)s' + \
               ' && npm activate %(pack)s'
 

--- a/tests/nodeenv_test.py
+++ b/tests/nodeenv_test.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import os.path
-import pipes
 import subprocess
 import sys
 import sysconfig
@@ -17,6 +16,11 @@ import pytest
 import nodeenv
 from nodeenv import IncompleteRead
 
+if sys.version_info >= (3, 3):
+    from shlex import quote
+else:
+    from pipes import quote
+
 HERE = os.path.abspath(os.path.dirname(__file__))
 
 
@@ -29,7 +33,7 @@ def test_smoke(tmpdir):
         '-m', 'nodeenv', '--prebuilt', nenv_path,
     ])
     assert os.path.exists(nenv_path)
-    activate = pipes.quote(os.path.join(nenv_path, 'bin', 'activate'))
+    activate = quote(os.path.join(nenv_path, 'bin', 'activate'))
     subprocess.check_call([
         'sh', '-c', '. {} && node --version'.format(activate),
     ])
@@ -44,7 +48,7 @@ def test_smoke_n_system_special_chars(tmpdir):
         '-m', 'nodeenv', '-n', 'system', nenv_path,
     ))
     assert os.path.exists(nenv_path)
-    activate = pipes.quote(os.path.join(nenv_path, 'bin', 'activate'))
+    activate = quote(os.path.join(nenv_path, 'bin', 'activate'))
     subprocess.check_call([
         'sh', '-c', '. {} && node --version'.format(activate),
     ])


### PR DESCRIPTION
closes #341

In recent versions of Python, `pipes.quote` is an alias for `shlex.quote`, but that function is only available from Python 3.3. This patch should work transparently in all supported versions of Python and avoid deprecation warnings in all cases.