### PR TITLE
Support shells with "set -u"

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -1256,17 +1256,17 @@ ACTIVATE_SH = r"""
 
 deactivate_node () {
     # reset old environment variables
-    if [ -n "$_OLD_NODE_VIRTUAL_PATH" ] ; then
-        PATH="$_OLD_NODE_VIRTUAL_PATH"
+    if [ -n "${_OLD_NODE_VIRTUAL_PATH:-}" ] ; then
+        PATH="${_OLD_NODE_VIRTUAL_PATH:-}"
         export PATH
         unset _OLD_NODE_VIRTUAL_PATH
 
-        NODE_PATH="$_OLD_NODE_PATH"
+        NODE_PATH="${_OLD_NODE_PATH:-}"
         export NODE_PATH
         unset _OLD_NODE_PATH
 
-        NPM_CONFIG_PREFIX="$_OLD_NPM_CONFIG_PREFIX"
-        npm_config_prefix="$_OLD_npm_config_prefix"
+        NPM_CONFIG_PREFIX="${_OLD_NPM_CONFIG_PREFIX:-}"
+        npm_config_prefix="${_OLD_npm_config_prefix:-}"
         export NPM_CONFIG_PREFIX
         export npm_config_prefix
         unset _OLD_NPM_CONFIG_PREFIX
@@ -1276,18 +1276,18 @@ deactivate_node () {
     # This should detect bash and zsh, which have a hash command that must
     # be called to get it to forget past commands.  Without forgetting
     # past commands the $PATH changes we made may not be respected
-    if [ -n "$BASH" -o -n "$ZSH_VERSION" ] ; then
+    if [ -n "${BASH:-}" -o -n "${ZSH_VERSION:-}" ] ; then
         hash -r
     fi
 
-    if [ -n "$_OLD_NODE_VIRTUAL_PS1" ] ; then
-        PS1="$_OLD_NODE_VIRTUAL_PS1"
+    if [ -n "${_OLD_NODE_VIRTUAL_PS1:-}" ] ; then
+        PS1="${_OLD_NODE_VIRTUAL_PS1:-}"
         export PS1
         unset _OLD_NODE_VIRTUAL_PS1
     fi
 
     unset NODE_VIRTUAL_ENV
-    if [ ! "$1" = "nondestructive" ] ; then
+    if [ ! "${1:-}" = "nondestructive" ] ; then
     # Self destruct!
         unset -f deactivate_node
     fi
@@ -1301,7 +1301,7 @@ freeze () {
                   cut -d ' ' -f 1 | grep -v npm`
     else
         local npmls="npm ls -g"
-        if [ "$1" = "-l" ]; then
+        if [ "${1:-}" = "-l" ]; then
             npmls="npm ls"
             shift
         fi
@@ -1321,7 +1321,7 @@ deactivate_node nondestructive
 
 # find the directory of this script
 # http://stackoverflow.com/a/246128
-if [ "${BASH_SOURCE}" ] ; then
+if [ "${BASH_SOURCE:-}" ] ; then
     SOURCE="${BASH_SOURCE[0]}"
 
     while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
@@ -1341,28 +1341,28 @@ _OLD_NODE_VIRTUAL_PATH="$PATH"
 PATH="$NODE_VIRTUAL_ENV/lib/node_modules/.bin:$NODE_VIRTUAL_ENV/__BIN_NAME__:$PATH"
 export PATH
 
-_OLD_NODE_PATH="$NODE_PATH"
+_OLD_NODE_PATH="${NODE_PATH:-}"
 NODE_PATH="$NODE_VIRTUAL_ENV/__MOD_NAME__"
 export NODE_PATH
 
-_OLD_NPM_CONFIG_PREFIX="$NPM_CONFIG_PREFIX"
-_OLD_npm_config_prefix="$npm_config_prefix"
+_OLD_NPM_CONFIG_PREFIX="${NPM_CONFIG_PREFIX:-}"
+_OLD_npm_config_prefix="${npm_config_prefix:-}"
 NPM_CONFIG_PREFIX="__NPM_CONFIG_PREFIX__"
 npm_config_prefix="__NPM_CONFIG_PREFIX__"
 export NPM_CONFIG_PREFIX
 export npm_config_prefix
 
-if [ -z "$NODE_VIRTUAL_ENV_DISABLE_PROMPT" ] ; then
-    _OLD_NODE_VIRTUAL_PS1="$PS1"
+if [ -z "${NODE_VIRTUAL_ENV_DISABLE_PROMPT:-}" ] ; then
+    _OLD_NODE_VIRTUAL_PS1="${PS1:-}"
     if [ "x__NODE_VIRTUAL_PROMPT__" != x ] ; then
-        PS1="__NODE_VIRTUAL_PROMPT__ $PS1"
+        PS1="__NODE_VIRTUAL_PROMPT__ ${PS1:-}"
     else
     if [ "`basename \"$NODE_VIRTUAL_ENV\"`" = "__" ] ; then
         # special case for Aspen magic directories
         # see http://www.zetadev.com/software/aspen/
-        PS1="[`basename \`dirname \"$NODE_VIRTUAL_ENV\"\``] $PS1"
+        PS1="[`basename \`dirname \"$NODE_VIRTUAL_ENV\"\``] ${PS1:-}"
     else
-        PS1="(`basename \"$NODE_VIRTUAL_ENV\"`) $PS1"
+        PS1="(`basename \"$NODE_VIRTUAL_ENV\"`) ${PS1:-}"
     fi
     fi
     export PS1
@@ -1371,7 +1371,7 @@ fi
 # This should detect bash and zsh, which have a hash command that must
 # be called to get it to forget past commands.  Without forgetting
 # past commands the $PATH changes we made may not be respected
-if [ -n "$BASH" -o -n "$ZSH_VERSION" ] ; then
+if [ -n "${BASH:-}" -o -n "${ZSH_VERSION:-}" ] ; then
     hash -r
 fi
 """


### PR DESCRIPTION
Currently the nodeenv activation code cannot run in bash/zsh shells with "set -u" enabled. This PR fixes it.

Usually you activate virtual environments in an interactive shell, but sometimes it is useful to do it inside a shell script. When writing shell scripts it is often recommended to enable additional strict error checking options, for example `set -e -u -o pipefail`. `-u` means reading undefined variables is an error.

It is based on the equivalent change in CPython:

* PR: https://github.com/python/cpython/pull/3804
* Bug: https://github.com/python/cpython/issues/69538
* PR2: https://github.com/python/cpython/pull/15330
* Bug2: https://github.com/python/cpython/issues/82066

Example before this PR:

```shellsession
$ python3 -m venv test1
$ test1/bin/pip install nodeenv
Collecting nodeenv
  Using cached nodeenv-1.8.0-py2.py3-none-any.whl (22 kB)
Requirement already satisfied: setuptools in ./test1/lib/python3.10/site-packages (from nodeenv) (59.6.0)
Installing collected packages: nodeenv
Successfully installed nodeenv-1.8.0
$ test1/bin/nodeenv -p
 * Install prebuilt node (21.2.0) ..... done.
 * Appending data to /home/tomi/tmpt/nodeenv/test1/bin/activate
 * Appending data to /home/tomi/tmpt/nodeenv/test1/bin/activate.fish
$ test1/bin/npm
ERROR: npm v10.2.3 is known not to run on Node.js v12.22.9.  This version of npm supports the following node versions: `^18.17.0 || >=20.5.0`. You can find the latest version at https://nodejs.org/.
...
$ bash -c 'source test1/bin/activate; npm --version'
10.2.3
$ bash -c 'set -u; source test1/bin/activate; npm --version'
test1/bin/activate: line 82: _OLD_NODE_VIRTUAL_PATH: unbound variable
```

After this PR it works properly:

```shellsession
$ test3/bin/pip install ./nodeenv/
...
$ test3/bin/nodeenv -p
...
$ bash -c 'source test3/bin/activate; npm --version'
10.2.3
$ bash -c 'set -u; source test3/bin/activate; npm --version'
10.2.3
```

