### PR TITLE
Remove usage of non-portable `which`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,7 +211,7 @@ environment::
 
     $ workon my_env
     $ npm install -g coffee-script
-    $ which coffee
+    $ command -v coffee
     /home/monty/virtualenvs/my_env/bin/coffee
     
 Creating a virtual environment with a custom prompt:

--- a/README.ru.rst
+++ b/README.ru.rst
@@ -155,7 +155,7 @@ python'а::
 
     $ workon my_env
     $ npm install -g coffee-script
-    $ which coffee
+    $ command -v coffee
     /home/monty/virtualenvs/my_env/bin/coffee
 
 

--- a/nodeenv.py
+++ b/nodeenv.py
@@ -707,12 +707,8 @@ def build_node_from_src(env_dir, src_dir, node_src_dir, args):
         # Currently, the node.js build scripts are using python2.*,
         # therefore we need to temporarily point python exec to the
         # python 2.* version in this case.
-        try:
-            _, which_python2_output = callit(
-                ['which', 'python2'], args.verbose, True, node_src_dir, env
-            )
-            python2_path = which_python2_output[0]
-        except (OSError, IndexError):
+        python2_path = shutil.which('python2')
+        if not python2_path:
             raise OSError(
                 'Python >=3.0 virtualenv detected, but no python2 '
                 'command (required for building node.js) was found'


### PR DESCRIPTION
* Use Python's shutil.which() instead of shelling out to `which` to find Python 2
* Use `command -v` instead of `which` in README

Fixes: https://github.com/ekalinin/nodeenv/issues/333