### PR TITLE
Add Python 3.11 and 3.12 Test Coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
         - '3.9'
         - '3.10'
         - '3.11'
+        - '3.12'
 
     steps:
     - uses: actions/checkout@v3

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # These should match the GitHub Actions env list
-envlist = py27,py37,py38,py39,py310,py311
+envlist = py27,py37,py38,py39,py310,py311,py312
 
 [testenv]
 install_command = pip install {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # These should match the GitHub Actions env list
-envlist = py27,py37,py38,py39,py310
+envlist = py27,py37,py38,py39,py310,py311
 
 [testenv]
 install_command = pip install {opts} {packages}


### PR DESCRIPTION
Add Python 3.11 and 3.12 to tox and 3.12 to github actions.

#347 should be merged before this pull request, in order to see test results. 