### PR TITLE
Reduce build deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -5,26 +5,27 @@ nodeenv
 
 Node.js Virtual Environment builder.
 """
+import re
 import codecs
 import os
 import sys
 
 from setuptools import setup
 
-sys.path.insert(0, '.')
-
-from nodeenv import nodeenv_version
-
 
 def read_file(file_name):
-    return codecs.open(
+    with codecs.open(
         os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
             file_name
         ),
         encoding='utf-8',
-    ).read()
+    ) as f:
+        return f.read()
 
+
+code = read_file('nodeenv.py')
+nodeenv_version = re.search(r"^nodeenv_version = '([^']+)'$", code, re.M).group(1)
 
 ldesc = read_file('README.rst')
 ldesc += "\n\n" + read_file('CHANGES')


### PR DESCRIPTION
This gets rid of all build dependencies mentioned in https://github.com/ekalinin/nodeenv/pull/338#pullrequestreview-1780231136 other than `setuptools` by parsing the version from the code instead of importing it at build time.

An alternative to hackily parsing like this would be to switch to https://flit.pypa.io (#350), which is faster than setuptools and parses the version from the module by default.

CI failures are fixed in #347