### PR TITLE
Support leading `v` in `.node-version`

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -138,7 +138,7 @@ class Config(object):
 
         if os.path.exists(".node-version"):
             with open(".node-version", "r") as v_file:
-                setattr(cls, "node", v_file.readlines(1)[0].strip())
+                setattr(cls, "node", v_file.readline().strip().lstrip("v"))
 
     @classmethod
     def _dump(cls):


### PR DESCRIPTION
From: https://github.com/shadowspawn/node-version-usage#suggested-compatible-format

>  Allowing a leading `v` is common and gives nice symmetry with `node --version`
```output
$ node --version
v20.12.0
$ node --version > .node-version
```