### PR TITLE
Make tox configuration more flexible

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 # These should match the GitHub Actions env list
 envlist = py37,py38,py39,py310,py311,py312,py313
+minversion = 4.0.0
 
 [testenv]
-install_command = pip install {opts} {packages}
 deps = -rrequirements-dev.txt
 setenv =
     LANG=en_US.UTF-8


### PR DESCRIPTION
Ensures newer versions of tox is used and avoid direct uses of pip
as would not work with alternative installers like uv (which can
be activated using tox-uv).
