### PR TITLE
Add UV Virtual Environment support

### DIFF
--- a/nodeenv.py
+++ b/nodeenv.py
@@ -1088,6 +1088,8 @@ def get_env_dir(args):
             res = sys.prefix
         elif 'CONDA_PREFIX' in os.environ:
             res = sys.prefix
+        elif 'VIRTUAL_ENV' in os.environ:
+            res = os.environ['VIRTUAL_ENV']
         else:
             logger.error('No python virtualenv is available')
             sys.exit(2)


### PR DESCRIPTION
I made a small fix that includes the ability of detecting if the user using using a [UV virtual environment](https://github.com/astral-sh/uv).

I had a case scenario where I am working with __aiohttp__ in an developer virtual environment on windows and I needed  a way to interact with a fast package manager for python while also being able to generate the llhttp (C Parser library) code that I need for working with that library.

My fix seems to work ok. The only side effect might be that it removes the uv's powershell scripts.
