### PR TITLE
Use sh instead of bash

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -263,7 +263,7 @@ There are several alternatives that create isolated environments:
   Nave stores all environments in one directory ``~/.nave``. Can create
   per node version environments using `nave use envname versionname`.
   Can not pass additional arguments into configure (for example --without-ssl)
-  Can't run on windows because it relies on bash.
+  Can't run on windows because it relies on a POSIX shell.
 
 * `nvm <https://github.com/creationix/nvm/blob/master/nvm.sh>`_ - Node Version
   Manager. It is necessarily to do `nvm sync` for caching available node.js

--- a/nodeenv.py
+++ b/nodeenv.py
@@ -816,7 +816,7 @@ def install_npm(env_dir, _src_dir, args):
     )
     proc = subprocess.Popen(
         (
-            'bash', '-c',
+            'sh', '-c',
             '. {0} && npm install -g npm@{1}'.format(
                 _quote(join(env_dir, 'bin', 'activate')),
                 args.npm,
@@ -1177,7 +1177,7 @@ set -e NODE_VIRTUAL_ENV_DISABLE_PROMPT
 """,
 }
 
-SHIM = """#!/usr/bin/env bash
+SHIM = """#!/usr/bin/env sh
 export NODE_PATH='__NODE_VIRTUAL_ENV__/lib/node_modules'
 export NPM_CONFIG_PREFIX='__NODE_VIRTUAL_ENV__'
 export npm_config_prefix='__NODE_VIRTUAL_ENV__'
@@ -1279,7 +1279,7 @@ $env:PATH = "$env:NODE_VIRTUAL_ENV\Scripts;$env:PATH"
 
 ACTIVATE_SH = r"""
 
-# This file must be used with "source bin/activate" *from bash*
+# This file must be used with "source bin/activate" *from sh*
 # you cannot run it directly
 
 deactivate_node () {


### PR DESCRIPTION
Currently bash is used to run some pretty trivial commands, but these commands don't require anything bash-specific and can run with a regular POSIX shell.

Use sh instead, to remove bash as a dependency for this package. There is no need to update the list of dependencies since bash was already missing from this list.